### PR TITLE
feat: add admin dashboard and local content API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.next/
+.env*
+.DS_Store
+npm-debug.log*
+*.log

--- a/data/db.json
+++ b/data/db.json
@@ -1,0 +1,53 @@
+{
+  "users": [],
+  "slider": [
+    {
+      "id": 1,
+      "imageUrl": "https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=1600&q=80",
+      "captionText": "Bienvenidos a la Escuela de Arte",
+      "createdAt": 1738886400000
+    },
+    {
+      "id": 2,
+      "imageUrl": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80",
+      "captionText": "Explorá nuestra propuesta educativa",
+      "createdAt": 1738972800000
+    }
+  ],
+  "agenda": [
+    {
+      "id": 1,
+      "titulo": "Clínica de grabado contemporáneo",
+      "descripcion": "Un espacio práctico para experimentar con nuevas técnicas de grabado.",
+      "fecha": "2025-03-21",
+      "imageUrl": "https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=1200&q=80"
+    },
+    {
+      "id": 2,
+      "titulo": "Muestra anual de estudiantes",
+      "descripcion": "Exhibición colectiva con obras de todas las carreras.",
+      "fecha": "2025-04-12",
+      "imageUrl": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+    }
+  ],
+  "usina": [
+    {
+      "id": 1,
+      "titulo": "Laboratorio de proyectos colaborativos",
+      "texto": "Un espacio para el desarrollo de iniciativas interdisciplinarias que vinculan a estudiantes, docentes y la comunidad.",
+      "imageUrl": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+    }
+  ],
+  "textos": [
+    {
+      "id": 1,
+      "seccion": "texto-introduccion",
+      "contenido": "Somos un espacio público de formación artística con más de 80 años de historia."
+    },
+    {
+      "id": 2,
+      "seccion": "texto-introduccion2",
+      "contenido": "Acompañamos a cada estudiante en la construcción de su propio recorrido creativo."
+    }
+  ]
+}

--- a/src/app/api/_lib/auth.js
+++ b/src/app/api/_lib/auth.js
@@ -1,0 +1,102 @@
+import crypto from 'crypto';
+import { NextResponse } from 'next/server';
+import { readDatabase } from './db';
+
+const DEFAULT_EXP_SECONDS = 60 * 60 * 8; // 8 horas
+
+function base64UrlEncode(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function base64UrlDecode(value) {
+  return Buffer.from(value, 'base64url').toString('utf8');
+}
+
+export function hashPassword(password, salt = crypto.randomBytes(16).toString('hex')) {
+  const hash = crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha512').toString('hex');
+  return `${salt}:${hash}`;
+}
+
+export function verifyPassword(password, storedHash) {
+  if (!storedHash) return false;
+  const [salt, originalHash] = storedHash.split(':');
+  if (!salt || !originalHash) return false;
+  const hash = crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha512').toString('hex');
+  return crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(originalHash, 'hex'));
+}
+
+export function signToken(payload, { expiresIn = DEFAULT_EXP_SECONDS } = {}) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const now = Math.floor(Date.now() / 1000);
+  const body = { ...payload, iat: now, exp: now + expiresIn };
+  const secret = process.env.AUTH_SECRET || 'local-secret';
+
+  const headerEncoded = base64UrlEncode(JSON.stringify(header));
+  const payloadEncoded = base64UrlEncode(JSON.stringify(body));
+  const data = `${headerEncoded}.${payloadEncoded}`;
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(data)
+    .digest('base64url');
+
+  return `${data}.${signature}`;
+}
+
+export function verifyToken(token) {
+  if (!token) throw new Error('Token ausente');
+  const secret = process.env.AUTH_SECRET || 'local-secret';
+  const [headerEncoded, payloadEncoded, signature] = token.split('.');
+  if (!headerEncoded || !payloadEncoded || !signature) {
+    throw new Error('Token malformado');
+  }
+  const data = `${headerEncoded}.${payloadEncoded}`;
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(data)
+    .digest('base64url');
+
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+    throw new Error('Firma inválida');
+  }
+
+  const payload = JSON.parse(base64UrlDecode(payloadEncoded));
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp && payload.exp < now) {
+    throw new Error('Token expirado');
+  }
+  return payload;
+}
+
+export async function requireAdmin(request) {
+  try {
+    const token = getTokenFromRequest(request);
+    const payload = verifyToken(token);
+    if (payload.role !== 'ADMIN') {
+      return NextResponse.json({ message: 'No autorizado' }, { status: 403 });
+    }
+    return { id: payload.sub, role: payload.role, email: payload.email, nombre: payload.nombre };
+  } catch (error) {
+    return NextResponse.json({ message: 'Token inválido' }, { status: 401 });
+  }
+}
+
+export function getTokenFromRequest(request) {
+  const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
+  if (!authHeader) throw new Error('Sin token');
+  const [, token] = authHeader.split(' ');
+  if (!token) throw new Error('Token ausente');
+  return token;
+}
+
+export async function getUserFromRequest(request) {
+  try {
+    const token = getTokenFromRequest(request);
+    const payload = verifyToken(token);
+    const db = await readDatabase();
+    const user = db.users.find((u) => u.id === payload.sub);
+    if (!user) throw new Error('Usuario no encontrado');
+    return { id: user.id, email: user.email, nombre: user.username, role: user.role };
+  } catch (error) {
+    return null;
+  }
+}

--- a/src/app/api/_lib/db.js
+++ b/src/app/api/_lib/db.js
@@ -1,0 +1,41 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DB_PATH = path.join(process.cwd(), 'data', 'db.json');
+
+async function ensureDatabase() {
+  try {
+    await fs.access(DB_PATH);
+  } catch {
+    await fs.mkdir(path.dirname(DB_PATH), { recursive: true });
+    const initialData = {
+      users: [],
+      slider: [],
+      agenda: [],
+      usina: [],
+      textos: []
+    };
+    await fs.writeFile(DB_PATH, JSON.stringify(initialData, null, 2), 'utf8');
+  }
+}
+
+export async function readDatabase() {
+  await ensureDatabase();
+  const raw = await fs.readFile(DB_PATH, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error('Error al parsear la base de datos JSON:', error);
+    throw new Error('Base de datos corrupta');
+  }
+}
+
+export async function writeDatabase(data) {
+  await fs.mkdir(path.dirname(DB_PATH), { recursive: true });
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2), 'utf8');
+}
+
+export function nextId(collection = []) {
+  if (collection.length === 0) return 1;
+  return Math.max(...collection.map((item) => item.id || 0)) + 1;
+}

--- a/src/app/api/agenda/[id]/route.js
+++ b/src/app/api/agenda/[id]/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase } from '../../_lib/db';
+import { requireAdmin } from '../../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function PUT(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const changes = await request.json();
+    const db = await readDatabase();
+    const index = db.agenda.findIndex((item) => item.id === id);
+    if (index === -1) {
+      return NextResponse.json({ message: 'Evento no encontrado.' }, { status: 404 });
+    }
+    db.agenda[index] = { ...db.agenda[index], ...changes, id };
+    await writeDatabase(db);
+    return NextResponse.json({ item: db.agenda[index] });
+  } catch (error) {
+    console.error('Error actualizando agenda:', error);
+    return NextResponse.json({ message: 'No se pudo actualizar el evento.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const db = await readDatabase();
+    const exists = db.agenda.some((item) => item.id === id);
+    if (!exists) {
+      return NextResponse.json({ message: 'Evento no encontrado.' }, { status: 404 });
+    }
+    db.agenda = db.agenda.filter((item) => item.id !== id);
+    await writeDatabase(db);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error eliminando agenda:', error);
+    return NextResponse.json({ message: 'No se pudo eliminar el evento.' }, { status: 500 });
+  }
+}

--- a/src/app/api/agenda/route.js
+++ b/src/app/api/agenda/route.js
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase, nextId } from '../_lib/db';
+import { requireAdmin } from '../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const db = await readDatabase();
+    return NextResponse.json({ items: db.agenda });
+  } catch (error) {
+    console.error('Error obteniendo agenda:', error);
+    return NextResponse.json({ message: 'No se pudo obtener la agenda.' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const { titulo, descripcion, fecha, imageUrl } = await request.json();
+    if (!titulo || !fecha) {
+      return NextResponse.json({ message: 'El título y la fecha son obligatorios.' }, { status: 400 });
+    }
+
+    const db = await readDatabase();
+    const newEvent = {
+      id: nextId(db.agenda),
+      titulo,
+      descripcion: descripcion || '',
+      fecha,
+      imageUrl: imageUrl || '',
+      createdAt: Date.now()
+    };
+    db.agenda.push(newEvent);
+    await writeDatabase(db);
+    return NextResponse.json({ item: newEvent }, { status: 201 });
+  } catch (error) {
+    console.error('Error creando agenda:', error);
+    return NextResponse.json({ message: 'No se pudo crear el evento.' }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/google/route.js
+++ b/src/app/api/auth/google/route.js
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase, nextId } from '../../_lib/db';
+import { hashPassword, signToken } from '../../_lib/auth';
+
+function createUsernameFromName(name, existingUsers) {
+  const base = name
+    .normalize('NFD')
+    .replace(/[^A-Za-z0-9 ]/g, '')
+    .trim()
+    .replace(/\s+/g, '.')
+    .toLowerCase() || 'usuario';
+  let username = base;
+  let counter = 1;
+  const taken = new Set(existingUsers.map((u) => u.username.toLowerCase()));
+  while (taken.has(username)) {
+    username = `${base}${counter}`;
+    counter += 1;
+  }
+  return username;
+}
+
+export async function POST(request) {
+  try {
+    const { email, name, googleId } = await request.json();
+    if (!email || !name || !googleId) {
+      return NextResponse.json({ message: 'Datos de Google incompletos.' }, { status: 400 });
+    }
+
+    const db = await readDatabase();
+    const normalizedEmail = email.toLowerCase();
+    const existingUser = db.users.find((user) => user.email.toLowerCase() === normalizedEmail);
+
+    if (existingUser) {
+      if (existingUser.googleId && existingUser.googleId !== googleId) {
+        return NextResponse.json({ message: 'El correo ya está registrado con otro proveedor.' }, { status: 409 });
+      }
+
+      if (!existingUser.googleId) {
+        existingUser.googleId = googleId;
+        await writeDatabase(db);
+      }
+
+      const token = signToken({
+        sub: existingUser.id,
+        email: existingUser.email,
+        role: existingUser.role,
+        nombre: existingUser.username
+      });
+
+      return NextResponse.json({
+        user: {
+          id: existingUser.id,
+          username: existingUser.username,
+          email: existingUser.email,
+          role: existingUser.role
+        },
+        token
+      });
+    }
+
+    const id = nextId(db.users);
+    const username = createUsernameFromName(name, db.users);
+    const passwordHash = hashPassword(googleId);
+    const role = db.users.length === 0 ? 'ADMIN' : 'USER';
+
+    const newUser = {
+      id,
+      username,
+      email,
+      passwordHash,
+      role,
+      googleId,
+      createdAt: Date.now()
+    };
+
+    db.users.push(newUser);
+    await writeDatabase(db);
+
+    const token = signToken({ sub: id, email, role, nombre: username });
+
+    return NextResponse.json({
+      user: { id, username, email, role },
+      token
+    });
+  } catch (error) {
+    console.error('Error en login con Google:', error);
+    return NextResponse.json({ message: 'No se pudo autenticar con Google.' }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { readDatabase } from '../../_lib/db';
+import { verifyPassword, signToken } from '../../_lib/auth';
+
+export async function POST(request) {
+  try {
+    const { identifier, password } = await request.json();
+
+    if (!identifier || !password) {
+      return NextResponse.json({ message: 'Credenciales incompletas.' }, { status: 400 });
+    }
+
+    const db = await readDatabase();
+    const normalized = identifier.toLowerCase();
+    const user = db.users.find(
+      (u) => u.email.toLowerCase() === normalized || u.username.toLowerCase() === normalized
+    );
+
+    if (!user || !verifyPassword(password, user.passwordHash)) {
+      return NextResponse.json({ message: 'Usuario o contraseña incorrectos.' }, { status: 401 });
+    }
+
+    const token = signToken({ sub: user.id, email: user.email, role: user.role, nombre: user.username });
+
+    return NextResponse.json({
+      user: { id: user.id, username: user.username, email: user.email, role: user.role },
+      token
+    });
+  } catch (error) {
+    console.error('Error en login:', error);
+    return NextResponse.json({ message: 'No se pudo iniciar sesión.' }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/me/route.js
+++ b/src/app/api/auth/me/route.js
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getUserFromRequest } from '../../_lib/auth';
+
+export async function GET(request) {
+  const user = await getUserFromRequest(request);
+  if (!user) {
+    return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+  }
+  return NextResponse.json({ user });
+}

--- a/src/app/api/auth/register/route.js
+++ b/src/app/api/auth/register/route.js
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase, nextId } from '../../_lib/db';
+import { hashPassword, signToken } from '../../_lib/auth';
+
+function validateEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function validateUsername(username) {
+  return /^[A-Za-z][A-Za-z0-9._-]{2,19}$/.test(username);
+}
+
+function validatePassword(password) {
+  return /^(?=.*[A-Za-z])(?=.*\d).{6,}$/.test(password);
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { username, email, password } = body;
+
+    if (!username || !email || !password) {
+      return NextResponse.json({ message: 'Todos los campos son obligatorios.' }, { status: 400 });
+    }
+
+    if (!validateUsername(username)) {
+      return NextResponse.json({ message: 'El nombre de usuario no es válido.' }, { status: 400 });
+    }
+
+    if (!validateEmail(email)) {
+      return NextResponse.json({ message: 'El correo electrónico no es válido.' }, { status: 400 });
+    }
+
+    if (!validatePassword(password)) {
+      return NextResponse.json({ message: 'La contraseña debe tener al menos 6 caracteres, incluyendo letras y números.' }, { status: 400 });
+    }
+
+    const db = await readDatabase();
+
+    if (db.users.some((user) => user.email.toLowerCase() === email.toLowerCase())) {
+      return NextResponse.json({ message: 'El correo electrónico ya está registrado.' }, { status: 409 });
+    }
+
+    if (db.users.some((user) => user.username.toLowerCase() === username.toLowerCase())) {
+      return NextResponse.json({ message: 'El nombre de usuario ya está en uso.' }, { status: 409 });
+    }
+
+    const id = nextId(db.users);
+    const passwordHash = hashPassword(password);
+    const role = db.users.length === 0 ? 'ADMIN' : 'USER';
+    const newUser = {
+      id,
+      username,
+      email,
+      passwordHash,
+      role,
+      googleId: null,
+      createdAt: Date.now()
+    };
+
+    db.users.push(newUser);
+    await writeDatabase(db);
+
+    const token = signToken({ sub: id, email, role, nombre: username });
+
+    return NextResponse.json({
+      user: { id, username, email, role },
+      token
+    });
+  } catch (error) {
+    console.error('Error en registro:', error);
+    return NextResponse.json({ message: 'No se pudo completar el registro.' }, { status: 500 });
+  }
+}

--- a/src/app/api/slider/[id]/route.js
+++ b/src/app/api/slider/[id]/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase } from '../../_lib/db';
+import { requireAdmin } from '../../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function PUT(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const changes = await request.json();
+    const db = await readDatabase();
+    const index = db.slider.findIndex((item) => item.id === id);
+    if (index === -1) {
+      return NextResponse.json({ message: 'Imagen no encontrada.' }, { status: 404 });
+    }
+    db.slider[index] = { ...db.slider[index], ...changes, id };
+    await writeDatabase(db);
+    return NextResponse.json({ item: db.slider[index] });
+  } catch (error) {
+    console.error('Error actualizando slider:', error);
+    return NextResponse.json({ message: 'No se pudo actualizar la imagen.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const db = await readDatabase();
+    const exists = db.slider.some((item) => item.id === id);
+    if (!exists) {
+      return NextResponse.json({ message: 'Imagen no encontrada.' }, { status: 404 });
+    }
+    db.slider = db.slider.filter((item) => item.id !== id);
+    await writeDatabase(db);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error eliminando slider:', error);
+    return NextResponse.json({ message: 'No se pudo eliminar la imagen.' }, { status: 500 });
+  }
+}

--- a/src/app/api/slider/route.js
+++ b/src/app/api/slider/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase, nextId } from '../_lib/db';
+import { requireAdmin } from '../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const db = await readDatabase();
+    return NextResponse.json({ items: db.slider.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0)) });
+  } catch (error) {
+    console.error('Error obteniendo slider:', error);
+    return NextResponse.json({ message: 'No se pudieron obtener las imágenes del carrusel.' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const { imageUrl, captionText } = await request.json();
+    if (!imageUrl) {
+      return NextResponse.json({ message: 'La URL de la imagen es obligatoria.' }, { status: 400 });
+    }
+
+    const db = await readDatabase();
+    const newItem = {
+      id: nextId(db.slider),
+      imageUrl,
+      captionText: captionText || '',
+      createdAt: Date.now()
+    };
+    db.slider.push(newItem);
+    await writeDatabase(db);
+
+    return NextResponse.json({ item: newItem }, { status: 201 });
+  } catch (error) {
+    console.error('Error creando imagen de slider:', error);
+    return NextResponse.json({ message: 'No se pudo crear la imagen.' }, { status: 500 });
+  }
+}

--- a/src/app/api/textos/[id]/route.js
+++ b/src/app/api/textos/[id]/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase } from '../../_lib/db';
+import { requireAdmin } from '../../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function PUT(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const { contenido, seccion } = await request.json();
+    const db = await readDatabase();
+    const index = db.textos.findIndex((item) => item.id === id);
+    if (index === -1) {
+      return NextResponse.json({ message: 'Texto no encontrado.' }, { status: 404 });
+    }
+
+    if (typeof contenido === 'string') {
+      db.textos[index].contenido = contenido;
+    }
+    if (typeof seccion === 'string') {
+      db.textos[index].seccion = seccion;
+    }
+    db.textos[index].updatedAt = Date.now();
+    await writeDatabase(db);
+    return NextResponse.json({ item: db.textos[index] });
+  } catch (error) {
+    console.error('Error actualizando texto:', error);
+    return NextResponse.json({ message: 'No se pudo actualizar el texto.' }, { status: 500 });
+  }
+}

--- a/src/app/api/textos/route.js
+++ b/src/app/api/textos/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { readDatabase } from '../_lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const seccion = searchParams.get('seccion');
+    const db = await readDatabase();
+    if (seccion) {
+      const item = db.textos.find((t) => t.seccion === seccion);
+      return NextResponse.json({ item: item || null });
+    }
+    return NextResponse.json({ items: db.textos });
+  } catch (error) {
+    console.error('Error obteniendo textos:', error);
+    return NextResponse.json({ message: 'No se pudieron obtener los textos.' }, { status: 500 });
+  }
+}

--- a/src/app/api/usina/[id]/route.js
+++ b/src/app/api/usina/[id]/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase } from '../../_lib/db';
+import { requireAdmin } from '../../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function PUT(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const changes = await request.json();
+    const db = await readDatabase();
+    const index = db.usina.findIndex((item) => item.id === id);
+    if (index === -1) {
+      return NextResponse.json({ message: 'Registro no encontrado.' }, { status: 404 });
+    }
+    db.usina[index] = { ...db.usina[index], ...changes, id };
+    await writeDatabase(db);
+    return NextResponse.json({ item: db.usina[index] });
+  } catch (error) {
+    console.error('Error actualizando usina:', error);
+    return NextResponse.json({ message: 'No se pudo actualizar el registro.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const id = Number(params.id);
+    const db = await readDatabase();
+    const exists = db.usina.some((item) => item.id === id);
+    if (!exists) {
+      return NextResponse.json({ message: 'Registro no encontrado.' }, { status: 404 });
+    }
+    db.usina = db.usina.filter((item) => item.id !== id);
+    await writeDatabase(db);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error eliminando usina:', error);
+    return NextResponse.json({ message: 'No se pudo eliminar el registro.' }, { status: 500 });
+  }
+}

--- a/src/app/api/usina/route.js
+++ b/src/app/api/usina/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { readDatabase, writeDatabase, nextId } from '../_lib/db';
+import { requireAdmin } from '../_lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const db = await readDatabase();
+    return NextResponse.json({ items: db.usina });
+  } catch (error) {
+    console.error('Error obteniendo usina:', error);
+    return NextResponse.json({ message: 'No se pudo obtener la información.' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  const admin = await requireAdmin(request);
+  if (admin instanceof NextResponse) return admin;
+
+  try {
+    const { titulo, texto, imageUrl } = await request.json();
+    if (!titulo || !texto) {
+      return NextResponse.json({ message: 'El título y el texto son obligatorios.' }, { status: 400 });
+    }
+
+    const db = await readDatabase();
+    const newItem = {
+      id: nextId(db.usina),
+      titulo,
+      texto,
+      imageUrl: imageUrl || '',
+      createdAt: Date.now()
+    };
+    db.usina.push(newItem);
+    await writeDatabase(db);
+    return NextResponse.json({ item: newItem }, { status: 201 });
+  } catch (error) {
+    console.error('Error creando contenido de usina:', error);
+    return NextResponse.json({ message: 'No se pudo crear el contenido.' }, { status: 500 });
+  }
+}

--- a/src/app/componentes/basicos/acordeon/acordeon.js
+++ b/src/app/componentes/basicos/acordeon/acordeon.js
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import { getAcordeonByAcordeonID } from './acordeonByID';
-import { API_URL } from '@/app/config';
 
 export default function Acordeon({ acordeonID }) {
   const [labels, setLabels] = useState([]); // Almacena los ítems del acordeón

--- a/src/app/componentes/basicos/acordeon/acordeonByID.js
+++ b/src/app/componentes/basicos/acordeon/acordeonByID.js
@@ -1,22 +1,31 @@
-import { API_URL } from "@/app/config";
+const ACORDEONES = {
+    carreras: [
+        {
+            id: 1,
+            titulo: "Profesorado de Artes Visuales",
+            contenido: "Formación integral en pedagogía y prácticas visuales contemporáneas.",
+            color: "#f5c518"
+        },
+        {
+            id: 2,
+            titulo: "Tecnicatura en Diseño Multimedial",
+            contenido: "Experimentación con animación, fotografía y programación para experiencias digitales.",
+            color: "#ef6c8f"
+        },
+        {
+            id: 3,
+            titulo: "Tecnicatura en Cerámica",
+            contenido: "Talleres con enfoque en materialidad, volumen y producción artesanal.",
+            color: "#63c4c1"
+        }
+    ]
+};
 
-// Obtiene los textos del acordeón según el ID proporcionado
 export async function getAcordeonByAcordeonID(acordeonID) {
-  try {
-    // Llama a la API de acordeones filtrando por acordeonID y expandiendo relaciones
-    const response = await fetch(`${API_URL}/acordeons?filters[acordeonID][$eq]=${(acordeonID)}&populate=*`);
-    
-    if (!response.ok) {
-      throw new Error(`Error HTTP: ${response.status}`);
+    const key = acordeonID?.toLowerCase();
+    if (key && ACORDEONES[key]) {
+        return ACORDEONES[key];
     }
-
-    const { data } = await response.json();
-
-    // Devuelve los textos del primer resultado (estructura esperada del backend)
-    return data[0].textos || null;
-
-  } catch (error) {
-    console.error('Error al obtener acordeon:', error);
-    return null; // Devuelve null en caso de error
-  }
+    console.warn(`No se encontraron datos de acordeón para ${acordeonID}`);
+    return [];
 }

--- a/src/app/componentes/basicos/agenda.js
+++ b/src/app/componentes/basicos/agenda.js
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { API_URL } from "@/app/config";
 import Slider from 'react-slick'; // Librería para carruseles
 import ReactMarkdown from 'react-markdown'; // Para renderizar texto con formato Markdown
 import { FaArrowLeft, FaArrowRight } from 'react-icons/fa'; // Íconos de flechas
@@ -30,17 +29,14 @@ export default function Agenda() {
   useEffect(() => {
     async function fetchAgendas() {
       try {
-        // Llama a la API de agendas incluyendo las imágenes
-        const res = await fetch(`${API_URL}/agendas?populate=imagen`, {
-          cache: "no-store", // Evita usar caché (siempre solicita datos nuevos)
-        });
+        const res = await fetch(`/api/agenda`, { cache: 'no-store' });
         if (!res.ok) {
           console.error("Error en fetch:", res.statusText);
           return;
         }
 
-        const { data } = await res.json(); // Extrae los datos del JSON
-        setAgendas(data); // Almacena los datos en el estado
+        const { items } = await res.json();
+        setAgendas(Array.isArray(items) ? items : []);
       } catch (err) {
         console.error("Error en getAgendas:", err);
       }
@@ -90,8 +86,10 @@ export default function Agenda() {
         // Muestra el carrusel de agendas con sus datos
         <Slider ref={sliderRef} {...settings}>
           {agendas.map((item) => {
-            const { id, tituloActividad, contenidoActividad, fecha, imagen } = item;
-            const imageUrl = imagen.url;
+            const { id, titulo, descripcion, fecha, imageUrl } = item;
+            const fechaLegible = fecha
+              ? new Date(fecha).toLocaleDateString('es-AR', { year: 'numeric', month: 'long', day: 'numeric' })
+              : '';
 
             return (
               <div key={id} className="agenda-container">
@@ -108,16 +106,16 @@ export default function Agenda() {
                   {/* Información visible siempre */}
                   <div className="agenda-contenido">
                     <div className="fecha">
-                      <p>{fecha}</p>
+                      <p>{fechaLegible}</p>
                     </div>
                     {/* Título renderizado como markdown */}
                     <ReactMarkdown
                       components={{
-                        p: ({ node, ...props }) => <p className="texto-regular" {...props} />,
+                        p: ({ node, ...props }) => <p className="texto-regular" {...props} />, 
                         strong: ({ node, ...props }) => <strong className="texto-negrita" {...props} />
                       }}
                     >
-                      {tituloActividad}
+                      {titulo}
                     </ReactMarkdown>
                   </div>
 
@@ -125,16 +123,16 @@ export default function Agenda() {
                   <div className="agenda-contenido-hover">
                     <ReactMarkdown
                       components={{
-                        p: ({ node, ...props }) => <p className="texto-regular" {...props} />,
+                        p: ({ node, ...props }) => <p className="texto-regular" {...props} />, 
                         strong: ({ node, ...props }) => <strong className="texto-negrita" {...props} />
                       }}
                     >
-                      {tituloActividad}
+                      {titulo}
                     </ReactMarkdown>
 
                     {/* Texto adicional del evento */}
                     <div className="texto-contenido-actividad">
-                      <p>{contenidoActividad}</p>
+                      <p>{descripcion}</p>
                     </div>
                   </div>
                 </div>

--- a/src/app/componentes/basicos/carrusel.js
+++ b/src/app/componentes/basicos/carrusel.js
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { API_URL } from '@/app/config';
 import Slider from 'react-slick';
 import ReactMarkdown from 'react-markdown';
 import { FaArrowLeft, FaArrowRight } from 'react-icons/fa';
@@ -25,7 +24,7 @@ const NextArrow = ({ onClick }) => (
 export default function Carrusel() {
   const sliderRef = useRef(null); // Referencia al slider
   const [imagenesCarrusel, setImagenesCarrusel] = useState([]); // Imágenes del carrusel
-  const [title, setTitle] = useState(''); // Título global del carrusel
+  const [isLoading, setIsLoading] = useState(true);
 
   // Configuración del carrusel
   const settings = {
@@ -46,46 +45,44 @@ export default function Carrusel() {
 
   // Carga las imágenes del carrusel al montar el componente
   useEffect(() => {
-    fetch(`${API_URL}/carrusels?populate=carrusel`)
-      .then(res => res.json())
-      .then(data => {
-        const item = data.data?.[0];
-        if (item) {
-          setTitle(item.title); // Guarda el título
-          setImagenesCarrusel(item.carrusel ?? []); // Guarda las imágenes
-        }
+    fetch(`/api/slider`, { cache: 'no-store' })
+      .then(res => {
+        if (!res.ok) throw new Error('No se pudo obtener el carrusel');
+        return res.json();
       })
-      .catch(err => console.error('Error al cargar imágenes:', err));
+      .then((data) => {
+        setImagenesCarrusel(Array.isArray(data.items) ? data.items : []);
+      })
+      .catch(err => console.error('Error al cargar imágenes:', err))
+      .finally(() => setIsLoading(false));
   }, []);
 
   return (
     <div className="carrusel-container">
-      {/* Carrusel usando react-slick */}
-      <Slider ref={sliderRef} {...settings}>
-        {imagenesCarrusel.map((imagen, index) => {
-          // Obtiene la URL de la imagen (versión grande si existe)
-          const url = imagen.formats?.large?.url || imagen.url;
-          return (
-            <div key={`slide-${index}`} style={{ width: '100%' }}>
+      {isLoading ? (
+        <p className="carrusel-loading">Cargando carrusel…</p>
+      ) : imagenesCarrusel.length === 0 ? (
+        <p className="carrusel-empty">No hay imágenes disponibles.</p>
+      ) : (
+        <Slider ref={sliderRef} {...settings}>
+          {imagenesCarrusel.map((imagen) => (
+            <div key={imagen.id} className="slider-item">
               <div
-                className='carrusel-img'
+                className="slider-item__image"
                 style={{
-                  backgroundImage: `linear-gradient(rgba(120, 51, 51, 0.5), rgba(0, 0, 0, 0.5)), url(${url})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
+                  backgroundImage: `url(${imagen.imageUrl})`
                 }}
               >
-                {/* Muestra el título si existe */}
-                {title && (
-                  <div className='titulo'>
-                    <ReactMarkdown>{title}</ReactMarkdown>
+                {imagen.captionText && (
+                  <div className="slider-item__caption">
+                    <ReactMarkdown>{imagen.captionText}</ReactMarkdown>
                   </div>
                 )}
               </div>
             </div>
-          );
-        })}
-      </Slider>
+          ))}
+        </Slider>
+      )}
     </div>
   );
 }

--- a/src/app/componentes/basicos/imagen/imagen.js
+++ b/src/app/componentes/basicos/imagen/imagen.js
@@ -33,8 +33,8 @@ export const Imagen = ({ ImagenID, className }) => {
         fetchData();
     }, [ImagenID]);
 
-    if (status === 'loading') return <p className="text">Cargando...</p>;
-    if (status === 'error') return <p className="text">No se encontró la imagen</p>;
+    if (status === 'loading') return null;
+    if (status === 'error') return null;
 
     return (
         <div className={`relative ${className}`}>

--- a/src/app/componentes/basicos/imagen/imagenByID.js
+++ b/src/app/componentes/basicos/imagen/imagenByID.js
@@ -1,19 +1,14 @@
-import { API_URL } from "@/app/config";
+const STATIC_IMAGES = {
+  logo: "/img/Logo.PNG",
+};
 
 // Obtiene la URL de una imagen a partir de su imagenID
 export async function getImagenbyImagenID(ImagenID) {
-  try {
-    const response = await fetch(`${API_URL}/imagens?filters[imagenID][$eq]=${(ImagenID)}&populate=imagen`);
-    
-    if (!response.ok) {
-      throw new Error(`Error HTTP: ${response.status}`); // Si la respuesta no es OK, lanza error
-    }
-    
-    const { data } = await response.json();
-
-    return data[0].imagen.formats.thumbnail.url || null; // Devuelve la URL si existe
-  } catch (error) {
-    console.error('Error al obtener la imagen:', error);
-    return null; // En caso de error devuelve null
+  if (!ImagenID) return null;
+  const key = ImagenID.toLowerCase();
+  if (STATIC_IMAGES[key]) {
+    return STATIC_IMAGES[key];
   }
+  console.warn(`No se encontró una imagen estática para el ID ${ImagenID}`);
+  return null;
 }

--- a/src/app/componentes/basicos/texto/text.js
+++ b/src/app/componentes/basicos/texto/text.js
@@ -4,7 +4,6 @@ import { getTextoByTextoId } from "./textoById";
 import { checkUserRole } from '../../validacion/checkRole';
 import ReactMarkdown from 'react-markdown';
 import { handleSave } from '../../validacion/handleSave';
-import { API_URL } from "@/app/config";
 
 export const Texto = ({ textoID }) => {
     const jwt = typeof window !== "undefined" ? localStorage.getItem("jwt") : null;
@@ -20,7 +19,7 @@ export const Texto = ({ textoID }) => {
         // Verifica si el usuario es administrador
         const verifyAdmin = async () => {
             const role = await checkUserRole();
-            if (role === "Administrador") setIsAdmin(true);
+            if (role === "ADMIN") setIsAdmin(true);
         };
         
         verifyAdmin();
@@ -36,8 +35,9 @@ export const Texto = ({ textoID }) => {
             try {
                 const result = await getTextoByTextoId(textoID);
                 if (result) {
-                    setTexto(result);
-                    setEditedText(result);
+                    setTexto(result.contenido || '');
+                    setEditedText(result.contenido || '');
+                    setID(result.id);
                     setStatus('success');
                 } else {
                     setStatus('error');
@@ -46,13 +46,6 @@ export const Texto = ({ textoID }) => {
                 console.error('Fetch error:', error);
                 setStatus('error');
             }
-            const getRes = await fetch(`${API_URL}/textos?filters[textoID][$eq]=${textoID}`, {
-                headers: {
-                    'Authorization': `Bearer ${jwt}` // Agrega el token de autenticación
-                }
-            });
-            const getData = await getRes.json();
-            setID(getData.data[0].documentId);
 
         };
 
@@ -61,9 +54,17 @@ export const Texto = ({ textoID }) => {
 
     // Guarda los cambios realizados al texto
     const saveContent = async () => {
+        if (!realID) {
+            alert("No se pudo identificar el texto a actualizar");
+            return;
+        }
+        if (!jwt) {
+            alert("Debes iniciar sesión para editar");
+            return;
+        }
         try {
             await handleSave({
-                objetoAEditar: "texto",
+                objetoAEditar: "textos",
                 idObjeto: realID,
                 nuevoContenido: editedText,
                 jwt,
@@ -73,8 +74,8 @@ export const Texto = ({ textoID }) => {
             // Recarga el contenido actualizado desde el servidor
             const result = await getTextoByTextoId(textoID);
             if (result) {
-                setTexto(result);
-                setEditedText(result);
+                setTexto(result.contenido || '');
+                setEditedText(result.contenido || '');
             }
 
             setIsEditing(false); // Cierra modo edición

--- a/src/app/componentes/basicos/texto/textoById.js
+++ b/src/app/componentes/basicos/texto/textoById.js
@@ -1,19 +1,16 @@
-import { API_URL } from "@/app/config";
-
 // Función que obtiene un texto desde la API a partir de su textoID
 export async function getTextoByTextoId(textoID) {
   try {
-    // Realiza una consulta con filtro por textoID, incluyendo relaciones
-    const res = await fetch(`${API_URL}/textos?filters[textoID][$eq]=${textoID}&populate=*`);
-    
+    const params = new URLSearchParams({ seccion: textoID });
+    const res = await fetch(`/api/textos?${params.toString()}`);
+
     if (!res.ok) {
       throw new Error(`Error HTTP: ${res.status}`);
     }
 
-    const { data } = await res.json();
+    const { item } = await res.json();
 
-    // Devuelve el contenido del primer resultado si existe
-    return data[0]?.contenido || null;
+    return item || null;
   } catch (err) {
     console.error("Error al obtener texto:", err);
     return null;

--- a/src/app/componentes/basicos/usina.js
+++ b/src/app/componentes/basicos/usina.js
@@ -1,23 +1,27 @@
-import { API_URL } from "@/app/config";
+"use client";
 
-async function getUsinas() {
-  try {
-    const res = await fetch(`${API_URL}/usinas?populate=imagen`);
-    
-    if (!res.ok) {
-      console.error("Error en fetch:", res.statusText);
-      return [];
-    }
-    const { data } = await res.json();
-    return data;
-  } catch (err) {
-    console.error("Error en getUsinas:", err);
-    return [];
+import { useEffect, useState } from 'react';
+
+export default function Usina() {
+  const [usinas, setUsinas] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/usina', { cache: 'no-store' })
+      .then((res) => {
+        if (!res.ok) throw new Error('No se pudo obtener la información de Usina');
+        return res.json();
+      })
+      .then(({ items }) => {
+        setUsinas(Array.isArray(items) ? items : []);
+      })
+      .catch((err) => console.error('Error en getUsinas:', err))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) {
+    return <p className="usina-loading">Cargando contenido…</p>;
   }
-}
-
-export default async function Usina() {
-  const usinas = await getUsinas();
 
   return (
     <div className="usina-container">
@@ -25,27 +29,26 @@ export default async function Usina() {
         <p>No hay datos disponibles.</p>
       ) : (
         usinas.map((item) => {
-          const { id, nombre, carrera, link, imagen } = item;
-          const imageUrl = imagen?.url ?? '';
+          const { id, titulo, texto, imageUrl } = item;
 
           return (
-            <div key={id} className="usina-card" style={{
-                  backgroundImage: `url(${imageUrl})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                }}>
+            <div
+              key={id}
+              className="usina-card"
+              style={{
+                backgroundImage: `linear-gradient(rgba(7, 7, 7, 0.55), rgba(7,7,7,0.55)), url(${imageUrl || ''})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center'
+              }}
+            >
               <div className="usina-contenido">
-                <h2>{nombre}</h2>
-                <p>Carrera: {carrera}</p>
-                <a href={link} target="_blank" rel="noopener noreferrer">
-                Ver contacto
-                </a>
+                <h3>{titulo}</h3>
+                <p>{texto}</p>
               </div>
             </div>
           );
         })
       )}
-    </div>
-  );
+    </div>
+  );
 }
-    

--- a/src/app/componentes/crearComponentes/usinaProtegida.js
+++ b/src/app/componentes/crearComponentes/usinaProtegida.js
@@ -1,29 +1,53 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
-import CrearUsina from "./crearUsina"; // Ajustá la ruta si es necesario
 
 export default function UsinaProtegida() {
-  const [logueado, setLogueado] = useState(false);
-  const [verificado, setVerificado] = useState(false); // Esperamos a verificar
+  const [role, setRole] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const token = localStorage.getItem("jwt");
-    if (token && token.trim() !== "") {
-      setLogueado(true);
+    async function loadRole() {
+      const token = localStorage.getItem("jwt");
+      if (!token) {
+        setIsLoading(false);
+        return;
+      }
+      try {
+        const res = await fetch(`/api/auth/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error("No autenticado");
+        const data = await res.json();
+        setRole(data.user?.role ?? null);
+      } catch (error) {
+        console.error("No se pudo obtener el rol", error);
+      } finally {
+        setIsLoading(false);
+      }
     }
-    setVerificado(true); // Marcamos que ya se verificó
+
+    loadRole();
   }, []);
 
-  if (!verificado) return <p>Verificando sesión...</p>;
+  if (isLoading) return <p style={{ marginTop: "1rem" }}>Verificando sesión…</p>;
+
+  if (role !== "ADMIN") {
+    return (
+      <p style={{ marginTop: "1rem" }}>
+        ¿Formás parte del equipo de la Usina? <Link href="/login">Iniciá sesión</Link> con tu cuenta administrativa para
+        editar el contenido.
+      </p>
+    );
+  }
 
   return (
-    <div>
-      {logueado ? (
-        <CrearUsina />
-      ) : (
-        <p>Debes iniciar sesión para cargar una usina.</p>
-      )}
+    <div className="usina-protegida">
+      <p>
+        Sos administrador. Podés gestionar toda la sección desde el nuevo
+        <Link href="/dashboard" style={{ marginLeft: 4, textDecoration: "underline" }}>panel de control</Link>.
+      </p>
     </div>
   );
 }

--- a/src/app/componentes/login/iniciarSesion.js
+++ b/src/app/componentes/login/iniciarSesion.js
@@ -1,7 +1,6 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
-import { API_URL } from "@/app/config";
 import LoginWithGoogle from "./loginWithGoogle";
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
@@ -15,7 +14,7 @@ export default function LoginPage() {
     e.preventDefault();
 
     try {
-      const res = await fetch(`${API_URL}/auth/local`, {
+      const res = await fetch(`/api/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ identifier, password }),
@@ -23,9 +22,9 @@ export default function LoginPage() {
 
       const data = await res.json();
 
-      if (!res.ok) throw new Error(data?.error?.message || "Login inválido");
+      if (!res.ok) throw new Error(data?.message || "Login inválido");
 
-      localStorage.setItem("jwt", data.jwt);
+      localStorage.setItem("jwt", data.token);
       toast.success(`Bienvenido, ${data.user.username}!`);
       router.push("/"); // 🔹 redirige al inicio
     } catch (err) {

--- a/src/app/componentes/login/loginWithGoogle.js
+++ b/src/app/componentes/login/loginWithGoogle.js
@@ -2,10 +2,8 @@
 
 import { useGoogleLogin } from "@react-oauth/google";
 import axios from "axios";
-import { API_URL } from "@/app/config";
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
-import { API_TOKEN } from "@/app/config";
 
 export default function GoogleAuthButton({ mode = "login" }) {
   const router = useRouter();
@@ -22,50 +20,21 @@ export default function GoogleAuthButton({ mode = "login" }) {
 
         const { email, name, sub: googleId } = googleUser.data;
 
-        // 1. Verifico si ya existe usuario
-        const userCheckRes = await fetch(
-          `${API_URL}/users?filters[email][$eq]=${email}`,
-          {
-            headers: {
-              Authorization: `Bearer ${API_TOKEN}`, 
-            },
-          }
-        );
-
-        let exists = false;
-        try {
-          const data = await userCheckRes.json();
-          exists = data.length > 0;
-        } catch (err) {
-          console.warn("Error al verificar usuario existente:", err);
-        }
-
-        let authRes;
-        if (exists) {
-          // login
-          authRes = await fetch(`${API_URL}/auth/local`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ identifier: email, password: googleId }),
-          });
-        } else {
-          // registro
-          authRes = await fetch(`${API_URL}/auth/local/register`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              username: name,
-              email: email,
-              password: googleId,
-            }),
-          });
-        }
+        const authRes = await fetch(`/api/auth/google`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email,
+            name,
+            googleId,
+          }),
+        });
 
         const authData = await authRes.json();
         if (!authRes.ok)
-          throw new Error(authData?.error?.message || "Fallo de autenticación");
+          throw new Error(authData?.message || "Fallo de autenticación");
 
-        localStorage.setItem("jwt", authData.jwt);
+        localStorage.setItem("jwt", authData.token);
         toast.success(`Bienvenido, ${authData.user.username}!`);
         router.push("/"); // 🔹 redirige al inicio
       } catch (error) {

--- a/src/app/componentes/login/registrar.js
+++ b/src/app/componentes/login/registrar.js
@@ -1,7 +1,6 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { API_URL } from "@/app/config";
 import { toast } from "react-hot-toast";
 import Link from "next/link";
 import LoginWithGoogle from "./loginWithGoogle";
@@ -40,7 +39,7 @@ export default function Register() {
     }
 
     try {
-      const res = await fetch(`${API_URL}/auth/local/register`, {
+      const res = await fetch(`/api/auth/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, email, password }),
@@ -50,10 +49,10 @@ export default function Register() {
 
       if (res.ok) {
         // login automático y redirección
-        localStorage.setItem("jwt", data.jwt);
-        router.push("/"); 
+        localStorage.setItem("jwt", data.token);
+        router.push("/");
       } else {
-        toast.error(data?.error?.message || "Error en el registro.");
+        toast.error(data?.message || "Error en el registro.");
       }
     } catch (error) {
       console.error("Error:", error);

--- a/src/app/componentes/validacion/checkRole.js
+++ b/src/app/componentes/validacion/checkRole.js
@@ -1,5 +1,3 @@
-import { API_URL } from "@/app/config";
-
 // Función que verifica el rol del usuario autenticado
 export async function checkUserRole() {
   try {
@@ -7,23 +5,20 @@ export async function checkUserRole() {
 
     if (!jwt) return null;
 
-    // Consulta la información del usuario actual usando el JWT
-    const res = await fetch(`${API_URL}/users/me?populate=role`, {
+    const res = await fetch(`/api/auth/me`, {
       headers: {
         Authorization: `Bearer ${jwt}`
       }
     });
 
-    
-
     if (!res.ok) {
       throw new Error("Error al obtener el rol del usuario");
     }
 
-    const user = await res.json();
+    const { user } = await res.json();
 
     // Devuelve el rol del usuario
-    return user.role?.name || null;
+    return user?.role || null;
   } catch (err) {
     console.error("Error al verificar el rol:", err);
     return null;

--- a/src/app/componentes/validacion/handleSave.js
+++ b/src/app/componentes/validacion/handleSave.js
@@ -1,31 +1,24 @@
-import { API_URL } from "@/app/config";
-
 // Función reutilizable para guardar texto editado en cualquier tipo de objeto (texto, acordeón, etc.)
 export const handleSave = async ({ objetoAEditar, idObjeto, nuevoContenido, jwt, campoAModificar }) => {
     try {
-        // Actualiza el contenido del objeto usando PUT
-        const putRes = await fetch(`${API_URL}/${objetoAEditar}s/${idObjeto}`, {
+        const putRes = await fetch(`/api/${objetoAEditar}/${idObjeto}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${jwt}`
             },
             body: JSON.stringify({
-                data: {
-                    [campoAModificar]: nuevoContenido, // Guarda el nuevo contenido
-                },
+                [campoAModificar]: nuevoContenido,
             }),
         });
 
         const updated = await putRes.json();
 
-        // Si la actualización falla, lanza un error
         if (!putRes.ok) {
-            throw new Error(updated.error?.message || 'Error al guardar');
+            throw new Error(updated.message || 'Error al guardar');
         }
 
-        // Devuelve el nuevo contenido para actualizar el estado del frontend
-        return updated.data.texto;
+        return updated.item?.[campoAModificar];
     } catch (err) {
         console.error(err);
         throw err; // Permite que el componente que llama maneje el error

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -1,4 +1,4 @@
-export const API_URL = process.env.NEXT_PUBLIC_API_URL;
-export const URL = process.env.NEXT_PUBLIC_URL;
-export const clientIDGoogle = process.env.NEXT_PUBLIC_CLIENT_ID_GOOGLE;
-export const API_TOKEN = process.env.NEXT_PUBLIC_API_TOKEN;
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+export const URL = process.env.NEXT_PUBLIC_URL || '';
+export const clientIDGoogle = process.env.NEXT_PUBLIC_CLIENT_ID_GOOGLE || '';
+export const API_TOKEN = process.env.NEXT_PUBLIC_API_TOKEN || '';

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -1,0 +1,686 @@
+"use client";
+
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-hot-toast";
+
+const initialSlider = { imageUrl: "", captionText: "" };
+const initialAgenda = { titulo: "", descripcion: "", fecha: "", imageUrl: "" };
+const initialUsina = { titulo: "", texto: "", imageUrl: "" };
+
+export default function Dashboard() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+  const [user, setUser] = useState(null);
+
+  const [sliderItems, setSliderItems] = useState([]);
+  const [newSlider, setNewSlider] = useState(initialSlider);
+  const [editingSliderId, setEditingSliderId] = useState(null);
+  const [sliderDraft, setSliderDraft] = useState(initialSlider);
+
+  const [agendaItems, setAgendaItems] = useState([]);
+  const [newAgenda, setNewAgenda] = useState(initialAgenda);
+  const [agendaEditingId, setAgendaEditingId] = useState(null);
+  const [agendaDraft, setAgendaDraft] = useState(initialAgenda);
+
+  const [usinaItems, setUsinaItems] = useState([]);
+  const [newUsina, setNewUsina] = useState(initialUsina);
+  const [usinaEditingId, setUsinaEditingId] = useState(null);
+  const [usinaDraft, setUsinaDraft] = useState(initialUsina);
+
+  const [textos, setTextos] = useState([]);
+  const [textosDraft, setTextosDraft] = useState({});
+
+  const token = useMemo(() => (typeof window !== "undefined" ? localStorage.getItem("jwt") : null), []);
+
+  const authFetch = useCallback(
+    (url, options = {}) => {
+      const headers = { ...(options.headers || {}) };
+      if (token) headers.Authorization = `Bearer ${token}`;
+      return fetch(url, { ...options, headers });
+    },
+    [token]
+  );
+
+  const loadSlider = useCallback(async () => {
+    const res = await fetch(`/api/slider`, { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    setSliderItems(Array.isArray(data.items) ? data.items : []);
+  }, []);
+
+  const loadAgenda = useCallback(async () => {
+    const res = await fetch(`/api/agenda`, { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    setAgendaItems(Array.isArray(data.items) ? data.items : []);
+  }, []);
+
+  const loadUsina = useCallback(async () => {
+    const res = await fetch(`/api/usina`, { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    setUsinaItems(Array.isArray(data.items) ? data.items : []);
+  }, []);
+
+  const loadTextos = useCallback(async () => {
+    const res = await fetch(`/api/textos`, { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    if (Array.isArray(data.items)) {
+      setTextos(data.items);
+      const drafts = {};
+      data.items.forEach((texto) => {
+        drafts[texto.id] = texto.contenido;
+      });
+      setTextosDraft(drafts);
+    }
+  }, []);
+
+  useEffect(() => {
+    async function verifyAuth() {
+      if (!token) {
+        toast.error("Debés iniciar sesión");
+        router.push("/login");
+        setIsCheckingAuth(false);
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/auth/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error("No autenticado");
+        const data = await res.json();
+        if (data.user?.role !== "ADMIN") {
+          toast.error("Acceso restringido al equipo administrativo");
+          router.push("/");
+          return;
+        }
+        setUser(data.user);
+        await Promise.all([loadSlider(), loadAgenda(), loadUsina(), loadTextos()]);
+      } catch (error) {
+        console.error(error);
+        toast.error("No se pudo validar la sesión");
+        router.push("/login");
+      } finally {
+        setIsCheckingAuth(false);
+      }
+    }
+
+    verifyAuth();
+  }, [token, router, loadSlider, loadAgenda, loadUsina, loadTextos]);
+
+  const handleCreateSlider = async (event) => {
+    event.preventDefault();
+    if (!newSlider.imageUrl) {
+      toast.error("La imagen es obligatoria");
+      return;
+    }
+    try {
+      const res = await authFetch(`/api/slider`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newSlider),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo crear la imagen");
+      toast.success("Imagen añadida al carrusel");
+      setNewSlider(initialSlider);
+      loadSlider();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleUpdateSlider = async (id) => {
+    try {
+      const res = await authFetch(`/api/slider/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(sliderDraft),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo actualizar la imagen");
+      toast.success("Imagen actualizada");
+      setEditingSliderId(null);
+      loadSlider();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleDeleteSlider = async (id) => {
+    if (!confirm("¿Eliminar esta imagen del carrusel?")) return;
+    try {
+      const res = await authFetch(`/api/slider/${id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo eliminar la imagen");
+      toast.success("Imagen eliminada");
+      loadSlider();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleCreateAgenda = async (event) => {
+    event.preventDefault();
+    if (!newAgenda.titulo || !newAgenda.fecha) {
+      toast.error("Título y fecha son obligatorios");
+      return;
+    }
+    try {
+      const res = await authFetch(`/api/agenda`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newAgenda),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo crear el evento");
+      toast.success("Evento añadido a la agenda");
+      setNewAgenda(initialAgenda);
+      loadAgenda();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleUpdateAgenda = async (id) => {
+    try {
+      const res = await authFetch(`/api/agenda/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(agendaDraft),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo actualizar el evento");
+      toast.success("Evento actualizado");
+      setAgendaEditingId(null);
+      loadAgenda();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleDeleteAgenda = async (id) => {
+    if (!confirm("¿Eliminar este evento?")) return;
+    try {
+      const res = await authFetch(`/api/agenda/${id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo eliminar el evento");
+      toast.success("Evento eliminado");
+      loadAgenda();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleCreateUsina = async (event) => {
+    event.preventDefault();
+    if (!newUsina.titulo || !newUsina.texto) {
+      toast.error("Título y texto son obligatorios");
+      return;
+    }
+    try {
+      const res = await authFetch(`/api/usina`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newUsina),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo crear la tarjeta");
+      toast.success("Tarjeta de Usina creada");
+      setNewUsina(initialUsina);
+      loadUsina();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleUpdateUsina = async (id) => {
+    try {
+      const res = await authFetch(`/api/usina/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(usinaDraft),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo actualizar la tarjeta");
+      toast.success("Tarjeta actualizada");
+      setUsinaEditingId(null);
+      loadUsina();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleDeleteUsina = async (id) => {
+    if (!confirm("¿Eliminar esta tarjeta de Usina?")) return;
+    try {
+      const res = await authFetch(`/api/usina/${id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo eliminar la tarjeta");
+      toast.success("Tarjeta eliminada");
+      loadUsina();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  const handleSaveTexto = async (texto) => {
+    try {
+      const res = await authFetch(`/api/textos/${texto.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contenido: textosDraft[texto.id] ?? texto.contenido }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "No se pudo actualizar el texto");
+      toast.success("Texto guardado");
+      loadTextos();
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  if (isCheckingAuth) {
+    return (
+      <div className="dashboard-loading">
+        <p>Verificando credenciales…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard__header">
+        <div>
+          <h1>Panel de administración</h1>
+          <p>Gestioná el contenido público del sitio web.</p>
+        </div>
+        {user && (
+          <div className="dashboard__user">
+            <span>{user.nombre}</span>
+            <button
+              onClick={() => {
+                localStorage.removeItem("jwt");
+                router.push("/");
+              }}
+            >
+              Cerrar sesión
+            </button>
+          </div>
+        )}
+      </header>
+
+      <section className="dashboard-section">
+        <div className="section-head">
+          <h2>Carrusel</h2>
+          <p>Gestioná las imágenes destacadas del slider principal.</p>
+        </div>
+        <form className="dashboard-form" onSubmit={handleCreateSlider}>
+          <div className="form-grid">
+            <label>
+              URL de la imagen
+              <input
+                type="url"
+                value={newSlider.imageUrl}
+                onChange={(e) => setNewSlider({ ...newSlider, imageUrl: e.target.value })}
+                required
+              />
+            </label>
+            <label>
+              Texto del carrusel
+              <textarea
+                value={newSlider.captionText}
+                onChange={(e) => setNewSlider({ ...newSlider, captionText: e.target.value })}
+                placeholder="Texto superpuesto en la imagen"
+              />
+            </label>
+          </div>
+          <button type="submit">Añadir imagen</button>
+        </form>
+
+        <div className="dashboard-cards">
+          {sliderItems.map((item) => (
+            <div key={item.id} className="dashboard-card">
+              <img src={item.imageUrl} alt="Vista previa" className="dashboard-card__thumb" />
+              {editingSliderId === item.id ? (
+                <>
+                  <label>
+                    URL de la imagen
+                    <input
+                      type="url"
+                      value={sliderDraft.imageUrl}
+                      onChange={(e) => setSliderDraft({ ...sliderDraft, imageUrl: e.target.value })}
+                    />
+                  </label>
+                  <label>
+                    Texto del carrusel
+                    <textarea
+                      value={sliderDraft.captionText}
+                      onChange={(e) => setSliderDraft({ ...sliderDraft, captionText: e.target.value })}
+                    />
+                  </label>
+                  <div className="dashboard-card__actions">
+                    <button type="button" onClick={() => handleUpdateSlider(item.id)}>
+                      Guardar
+                    </button>
+                    <button
+                      type="button"
+                      className="button-secondary"
+                      onClick={() => {
+                        setEditingSliderId(null);
+                        setSliderDraft(initialSlider);
+                      }}
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p className="dashboard-card__text">{item.captionText || "(Sin texto)"}</p>
+                  <div className="dashboard-card__actions">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingSliderId(item.id);
+                        setSliderDraft({ imageUrl: item.imageUrl, captionText: item.captionText || "" });
+                      }}
+                    >
+                      Editar
+                    </button>
+                    <button type="button" className="button-danger" onClick={() => handleDeleteSlider(item.id)}>
+                      Eliminar
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="dashboard-section">
+        <div className="section-head">
+          <h2>Agenda</h2>
+          <p>Actualizá los eventos y actividades próximas.</p>
+        </div>
+        <form className="dashboard-form" onSubmit={handleCreateAgenda}>
+          <div className="form-grid">
+            <label>
+              Título
+              <input
+                type="text"
+                value={newAgenda.titulo}
+                onChange={(e) => setNewAgenda({ ...newAgenda, titulo: e.target.value })}
+                required
+              />
+            </label>
+            <label>
+              Fecha
+              <input
+                type="date"
+                value={newAgenda.fecha}
+                onChange={(e) => setNewAgenda({ ...newAgenda, fecha: e.target.value })}
+                required
+              />
+            </label>
+            <label>
+              URL de la imagen
+              <input
+                type="url"
+                value={newAgenda.imageUrl}
+                onChange={(e) => setNewAgenda({ ...newAgenda, imageUrl: e.target.value })}
+              />
+            </label>
+            <label className="form-grid-full">
+              Descripción
+              <textarea
+                value={newAgenda.descripcion}
+                onChange={(e) => setNewAgenda({ ...newAgenda, descripcion: e.target.value })}
+              />
+            </label>
+          </div>
+          <button type="submit">Agregar evento</button>
+        </form>
+
+        <div className="dashboard-cards">
+          {agendaItems.map((item) => {
+            const fechaLegible = item.fecha
+              ? new Date(item.fecha).toLocaleDateString("es-AR", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })
+              : "";
+            const isEditing = agendaEditingId === item.id;
+            return (
+              <div key={item.id} className="dashboard-card">
+                {item.imageUrl && <img src={item.imageUrl} alt="Vista previa" className="dashboard-card__thumb" />}
+                {isEditing ? (
+                  <>
+                    <label>
+                      Título
+                      <input
+                        type="text"
+                        value={agendaDraft.titulo}
+                        onChange={(e) => setAgendaDraft({ ...agendaDraft, titulo: e.target.value })}
+                      />
+                    </label>
+                    <label>
+                      Fecha
+                      <input
+                        type="date"
+                        value={agendaDraft.fecha}
+                        onChange={(e) => setAgendaDraft({ ...agendaDraft, fecha: e.target.value })}
+                      />
+                    </label>
+                    <label>
+                      URL de la imagen
+                      <input
+                        type="url"
+                        value={agendaDraft.imageUrl}
+                        onChange={(e) => setAgendaDraft({ ...agendaDraft, imageUrl: e.target.value })}
+                      />
+                    </label>
+                    <label>
+                      Descripción
+                      <textarea
+                        value={agendaDraft.descripcion}
+                        onChange={(e) => setAgendaDraft({ ...agendaDraft, descripcion: e.target.value })}
+                      />
+                    </label>
+                    <div className="dashboard-card__actions">
+                      <button type="button" onClick={() => handleUpdateAgenda(item.id)}>
+                        Guardar
+                      </button>
+                      <button
+                        type="button"
+                        className="button-secondary"
+                        onClick={() => {
+                          setAgendaEditingId(null);
+                          setAgendaDraft(initialAgenda);
+                        }}
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="dashboard-card__info">
+                      <h3>{item.titulo}</h3>
+                      <p className="dashboard-card__meta">{fechaLegible}</p>
+                      <p className="dashboard-card__text">{item.descripcion}</p>
+                    </div>
+                    <div className="dashboard-card__actions">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setAgendaEditingId(item.id);
+                          setAgendaDraft({
+                            titulo: item.titulo,
+                            descripcion: item.descripcion || "",
+                            fecha: item.fecha ? item.fecha.slice(0, 10) : "",
+                            imageUrl: item.imageUrl || "",
+                          });
+                        }}
+                      >
+                        Editar
+                      </button>
+                      <button type="button" className="button-danger" onClick={() => handleDeleteAgenda(item.id)}>
+                        Eliminar
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="dashboard-section">
+        <div className="section-head">
+          <h2>Usina</h2>
+          <p>Actualizá las tarjetas informativas de la sección Usina.</p>
+        </div>
+        <form className="dashboard-form" onSubmit={handleCreateUsina}>
+          <div className="form-grid">
+            <label>
+              Título
+              <input
+                type="text"
+                value={newUsina.titulo}
+                onChange={(e) => setNewUsina({ ...newUsina, titulo: e.target.value })}
+                required
+              />
+            </label>
+            <label>
+              URL de la imagen
+              <input
+                type="url"
+                value={newUsina.imageUrl}
+                onChange={(e) => setNewUsina({ ...newUsina, imageUrl: e.target.value })}
+              />
+            </label>
+            <label className="form-grid-full">
+              Texto
+              <textarea
+                value={newUsina.texto}
+                onChange={(e) => setNewUsina({ ...newUsina, texto: e.target.value })}
+                required
+              />
+            </label>
+          </div>
+          <button type="submit">Crear tarjeta</button>
+        </form>
+
+        <div className="dashboard-cards">
+          {usinaItems.map((item) => {
+            const isEditing = usinaEditingId === item.id;
+            return (
+              <div key={item.id} className="dashboard-card">
+                {item.imageUrl && <img src={item.imageUrl} alt="Vista previa" className="dashboard-card__thumb" />}
+                {isEditing ? (
+                  <>
+                    <label>
+                      Título
+                      <input
+                        type="text"
+                        value={usinaDraft.titulo}
+                        onChange={(e) => setUsinaDraft({ ...usinaDraft, titulo: e.target.value })}
+                      />
+                    </label>
+                    <label>
+                      URL de la imagen
+                      <input
+                        type="url"
+                        value={usinaDraft.imageUrl}
+                        onChange={(e) => setUsinaDraft({ ...usinaDraft, imageUrl: e.target.value })}
+                      />
+                    </label>
+                    <label>
+                      Texto
+                      <textarea
+                        value={usinaDraft.texto}
+                        onChange={(e) => setUsinaDraft({ ...usinaDraft, texto: e.target.value })}
+                      />
+                    </label>
+                    <div className="dashboard-card__actions">
+                      <button type="button" onClick={() => handleUpdateUsina(item.id)}>
+                        Guardar
+                      </button>
+                      <button
+                        type="button"
+                        className="button-secondary"
+                        onClick={() => {
+                          setUsinaEditingId(null);
+                          setUsinaDraft(initialUsina);
+                        }}
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="dashboard-card__info">
+                      <h3>{item.titulo}</h3>
+                      <p className="dashboard-card__text">{item.texto}</p>
+                    </div>
+                    <div className="dashboard-card__actions">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setUsinaEditingId(item.id);
+                          setUsinaDraft({
+                            titulo: item.titulo,
+                            texto: item.texto,
+                            imageUrl: item.imageUrl || "",
+                          });
+                        }}
+                      >
+                        Editar
+                      </button>
+                      <button type="button" className="button-danger" onClick={() => handleDeleteUsina(item.id)}>
+                        Eliminar
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="dashboard-section">
+        <div className="section-head">
+          <h2>Textos generales</h2>
+          <p>Editá los párrafos globales del sitio.</p>
+        </div>
+        <div className="dashboard-cards">
+          {textos.map((texto) => (
+            <div key={texto.id} className="dashboard-card dashboard-card--texto">
+              <div className="dashboard-card__info">
+                <h3>{texto.seccion}</h3>
+                <textarea
+                  value={textosDraft[texto.id] ?? ""}
+                  onChange={(e) => setTextosDraft({ ...textosDraft, [texto.id]: e.target.value })}
+                />
+              </div>
+              <div className="dashboard-card__actions">
+                <button type="button" onClick={() => handleSaveTexto(texto)}>
+                  Guardar cambios
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/hooks/useUser.js
+++ b/src/app/hooks/useUser.js
@@ -11,9 +11,8 @@ export function useUser() {
     try {
       const jwt = localStorage.getItem("jwt");
       if (!jwt) { setUser(null); setLoading(false); return; }
-      // Strapi v4 users-permissions:
-      const data = await apiFetch("/users/me?populate=*");
-      setUser(data || null);
+      const data = await apiFetch("/api/auth/me");
+      setUser(data.user || null);
     } catch (e) {
       console.error("useUser error:", e);
       setUser(null);

--- a/src/app/lib/api.js
+++ b/src/app/lib/api.js
@@ -9,15 +9,12 @@ export function toAbsoluteURL(path) {
 export async function apiFetch(path, options = {}) {
   const base = process.env.NEXT_PUBLIC_API_URL || '';
   const jwt = typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
-  const apiToken = process.env.NEXT_PUBLIC_API_TOKEN;
 
   const headers = {
     ...(options.headers || {}),
   };
 
-  // Si hay JWT de usuario, lo priorizamos; si no, token de API (opcional)
   if (jwt) headers.Authorization = `Bearer ${jwt}`;
-  else if (apiToken) headers.Authorization = `Bearer ${apiToken}`;
 
   const res = await fetch(`${base}${path}`, { ...options, headers });
   if (!res.ok) {

--- a/src/styles/componentes-styles.css
+++ b/src/styles/componentes-styles.css
@@ -111,8 +111,84 @@ h4{font-size: 20px; font-weight: 300;}
 .carrusel-container{
   width: 100%;
   height: 640px;
-  margin: 0 auto; 
+  margin: 0 auto;
   position: relative;
+}
+
+.carrusel-loading,
+.carrusel-empty {
+  text-align: center;
+  font-size: 1.25rem;
+  margin-top: 2rem;
+}
+
+.slider-item {
+  height: 640px;
+  padding: 0 1.5rem;
+  box-sizing: border-box;
+}
+
+.slider-item__image {
+  height: 100%;
+  width: 100%;
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.4s ease;
+}
+
+.slider-item__image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  transition: background 0.3s ease;
+}
+
+.slider-item__image:hover::after {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.slider-item__image:hover {
+  transform: scale(1.01);
+}
+
+.slider-item__caption {
+  position: relative;
+  z-index: 1;
+  color: #ffffff;
+  text-align: center;
+  max-width: 800px;
+  padding: 0 2rem;
+  font-size: clamp(1.5rem, 2vw + 1rem, 3rem);
+  line-height: 1.3;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.slider-item__image:hover .slider-item__caption {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.slider-item__caption p {
+  color: inherit;
+  margin: 0;
+}
+
+.usina-protegida {
+  margin-top: 1.5rem;
+  padding: 1rem 1.5rem;
+  background: rgba(255, 239, 15, 0.1);
+  border-left: 4px solid #ffef0f;
+  color: #fff;
+  border-radius: 12px;
 }
 
 .carrusel-width{

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -257,6 +257,239 @@ h4 { font-size: 20px; font-weight: 300; }
 
 .form-button-register:hover { background-color: #b0a50c; }
 
+/* Dashboard */
+.dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 3vw 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.dashboard-loading {
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.dashboard__header h1 {
+  font-size: clamp(2rem, 1.2rem + 2vw, 3rem);
+  margin-bottom: 0.25rem;
+}
+
+.dashboard__header p {
+  color: #cfcfcf;
+}
+
+.dashboard__user {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.dashboard__user span {
+  font-weight: 600;
+}
+
+.dashboard__user button {
+  background: #e6342e;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.dashboard__user button:hover {
+  background: #c72e29;
+}
+
+.dashboard-section {
+  background: #1c1a1b;
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-head p {
+  color: #bcbcbc;
+}
+
+.dashboard-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.form-grid-full {
+  grid-column: 1 / -1;
+}
+
+.dashboard-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #f7f7f7;
+}
+
+.dashboard-form input,
+.dashboard-form textarea,
+.dashboard-card input,
+.dashboard-card textarea {
+  background: #121112;
+  border: 1px solid #3a3a3a;
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  color: #f0f0f0;
+  font-size: 0.95rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 44px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-form textarea,
+.dashboard-card textarea {
+  min-height: 110px;
+}
+
+.dashboard-form input:focus,
+.dashboard-form textarea:focus,
+.dashboard-card input:focus,
+.dashboard-card textarea:focus {
+  outline: none;
+  border-color: #ffef0f;
+  box-shadow: 0 0 0 2px rgba(255, 239, 15, 0.25);
+}
+
+.dashboard-form button,
+.dashboard-card__actions button {
+  background: linear-gradient(120deg, #ffef0f, #f9c93d);
+  color: #1b1b1b;
+  font-weight: 700;
+  border: none;
+  border-radius: 10px;
+  padding: 0.7rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-form button:hover,
+.dashboard-card__actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(249, 201, 61, 0.35);
+}
+
+.dashboard-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.dashboard-card {
+  background: rgba(18, 17, 18, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 260px;
+  position: relative;
+}
+
+.dashboard-card__thumb {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dashboard-card__text {
+  color: #dddddd;
+  min-height: 60px;
+}
+
+.dashboard-card__meta {
+  color: #e6b42a;
+  font-weight: 600;
+}
+
+.dashboard-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.button-secondary {
+  background: transparent;
+  color: #ffef0f;
+  border: 1px solid rgba(255, 239, 15, 0.45);
+}
+
+.button-secondary:hover {
+  box-shadow: 0 10px 20px rgba(255, 239, 15, 0.25);
+}
+
+.button-danger {
+  background: #e6342e;
+  color: #fff;
+}
+
+.button-danger:hover {
+  box-shadow: 0 12px 24px rgba(230, 52, 46, 0.4);
+}
+
+.dashboard-card--texto textarea {
+  min-height: 140px;
+}
+
+@media (max-width: 900px) {
+  .dashboard {
+    padding: 2rem 1.5rem 3rem;
+  }
+
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard-section {
+    padding: 1.5rem;
+  }
+}
+
 /* Footer */
 footer {
   height: 100px;


### PR DESCRIPTION
## Summary
- add JSON-backed API routes for slider, agenda, usina, textos and authentication with local persistence
- build an admin dashboard to manage carousel, agenda, usina cards and general texts
- update public components to consume the new API and refresh carousel/usina styling

## Testing
- npm run lint *(fails: interactive setup prompt from Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e458f12c9c8331855420f46846475c