### PR TITLE
Add in-memory database fallback for backend

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -9,12 +9,22 @@ dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 dotenv.config();
 
+const DEFAULT_ADMIN_EMAIL = "admin@example.com";
+const DEFAULT_ADMIN_PASSWORD = "admin123";
+
+const postgresConfigProvided =
+  Boolean(process.env.DATABASE_URL) ||
+  ["PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD"].every((key) =>
+    Boolean(process.env[key])
+  );
+
 export const config = {
   port: process.env.PORT || 4000,
   clientUrl: process.env.CLIENT_URL || "http://localhost:3000",
   jwtSecret: process.env.JWT_SECRET || "malharro-dev-secret",
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || "8h",
-  adminEmail: process.env.ADMIN_EMAIL || "admin@example.com",
+  adminEmail: process.env.ADMIN_EMAIL || DEFAULT_ADMIN_EMAIL,
+  adminPassword: process.env.ADMIN_PASSWORD || DEFAULT_ADMIN_PASSWORD,
   smtp: {
     host: process.env.SMTP_HOST?.trim() || "",
     port: process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : undefined,
@@ -32,12 +42,43 @@ export const config = {
     password: process.env.PGPASSWORD,
     connectionString: process.env.DATABASE_URL,
   },
+  useInMemoryDb:
+    process.env.USE_IN_MEMORY_DB === "true" || !postgresConfigProvided,
 };
 
 export function assertConfig() {
-  const required = ["PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD", "JWT_SECRET", "ADMIN_EMAIL", "ADMIN_PASSWORD"];
+  const required = [];
+
+  if (!process.env.JWT_SECRET) {
+    console.warn(
+      "JWT_SECRET is not set. A fallback secret will be used for development. Set JWT_SECRET to secure production tokens."
+    );
+  }
+
+  if (!config.useInMemoryDb) {
+    required.push("PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD");
+  }
+
+  if (!process.env.ADMIN_EMAIL) {
+    console.warn(
+      `ADMIN_EMAIL is not set, using default value "${DEFAULT_ADMIN_EMAIL}".`
+    );
+  }
+
+  if (!process.env.ADMIN_PASSWORD) {
+    console.warn(
+      "ADMIN_PASSWORD is not set. A default development password will be used."
+    );
+  }
+
   const missing = required.filter((key) => !process.env[key]);
   if (missing.length) {
     console.warn(`Missing environment variables: ${missing.join(", ")}`);
+  }
+
+  if (config.useInMemoryDb) {
+    console.info(
+      "Using in-memory PostgreSQL. Provide database credentials or set USE_IN_MEMORY_DB=false to connect to a real database."
+    );
   }
 }

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -2,17 +2,93 @@ import { Pool } from "pg";
 import bcrypt from "bcryptjs";
 import { config } from "./config.js";
 
-const pool = new Pool({
-  connectionString: config.postgres.connectionString,
-  host: config.postgres.host,
-  port: config.postgres.port,
-  database: config.postgres.database,
-  user: config.postgres.user,
-  password: config.postgres.password,
-  ssl: process.env.PGSSLMODE === "require" ? { rejectUnauthorized: false } : undefined,
-});
+const memoryStore = createEmptyMemoryStore();
+const memorySequences = createInitialSequences();
+
+let usingInMemory = config.useInMemoryDb;
+let pool = usingInMemory ? null : createPgPool();
+
+function createPgPool() {
+  return new Pool({
+    connectionString: config.postgres.connectionString,
+    host: config.postgres.host,
+    port: config.postgres.port,
+    database: config.postgres.database,
+    user: config.postgres.user,
+    password: config.postgres.password,
+    ssl:
+      process.env.PGSSLMODE === "require"
+        ? { rejectUnauthorized: false }
+        : undefined,
+  });
+}
+
+function createEmptyMemoryStore() {
+  return {
+    users: [],
+    loginCodes: [],
+    carouselSlides: [],
+    agendaEvents: [],
+    usinaPosts: [],
+    siteTexts: [],
+    siteSections: new Map(),
+    faqs: [],
+  };
+}
+
+function createInitialSequences() {
+  return {
+    users: 0,
+    loginCodes: 0,
+    carouselSlides: 0,
+    agendaEvents: 0,
+    usinaPosts: 0,
+    siteTexts: 0,
+    faqs: 0,
+  };
+}
+
+function resetMemoryStore() {
+  memoryStore.users = [];
+  memoryStore.loginCodes = [];
+  memoryStore.carouselSlides = [];
+  memoryStore.agendaEvents = [];
+  memoryStore.usinaPosts = [];
+  memoryStore.siteTexts = [];
+  memoryStore.siteSections = new Map();
+  memoryStore.faqs = [];
+
+  for (const key of Object.keys(memorySequences)) {
+    memorySequences[key] = 0;
+  }
+}
+
+function nextMemoryId(table) {
+  if (!Object.prototype.hasOwnProperty.call(memorySequences, table)) {
+    throw new Error(`Unknown in-memory table: ${table}`);
+  }
+  memorySequences[table] += 1;
+  return memorySequences[table];
+}
+
+function isConnectionError(error) {
+  if (!error) return false;
+  if (error.code === "ECONNREFUSED" || error.code === "ENOTFOUND") {
+    return true;
+  }
+
+  if (error.errors && Array.isArray(error.errors)) {
+    return error.errors.some((innerError) => isConnectionError(innerError));
+  }
+
+  return false;
+}
 
 export async function query(text, params) {
+  if (usingInMemory) {
+    throw new Error("Direct SQL queries are not available while using the in-memory database.");
+  }
+
   const client = await pool.connect();
   try {
     return await client.query(text, params);
@@ -21,93 +97,7 @@ export async function query(text, params) {
   }
 }
 
-export async function initializeDatabase() {
-  await query(`CREATE TABLE IF NOT EXISTS users (
-    id SERIAL PRIMARY KEY,
-    email TEXT UNIQUE NOT NULL,
-    password_hash TEXT NOT NULL,
-    role TEXT NOT NULL DEFAULT 'ADMIN'
-  );`);
-
-  await query(`CREATE TABLE IF NOT EXISTS carousel_slides (
-    id SERIAL PRIMARY KEY,
-    image_url TEXT NOT NULL,
-    image_desktop_url TEXT DEFAULT '',
-    image_mobile_url TEXT DEFAULT '',
-    caption_text TEXT DEFAULT '',
-    position INTEGER DEFAULT 0
-  );`);
-
-  await query(
-    "ALTER TABLE carousel_slides ADD COLUMN IF NOT EXISTS image_desktop_url TEXT DEFAULT ''"
-  );
-  await query(
-    "ALTER TABLE carousel_slides ADD COLUMN IF NOT EXISTS image_mobile_url TEXT DEFAULT ''"
-  );
-
-  await query(`CREATE TABLE IF NOT EXISTS agenda_events (
-    id SERIAL PRIMARY KEY,
-    titulo TEXT NOT NULL,
-    descripcion TEXT DEFAULT '',
-    fecha DATE,
-    image_url TEXT DEFAULT '',
-    tags TEXT[] DEFAULT ARRAY[]::TEXT[]
-  );`);
-
-  await query(`CREATE TABLE IF NOT EXISTS usina_posts (
-    id SERIAL PRIMARY KEY,
-    titulo TEXT NOT NULL,
-    texto TEXT DEFAULT '',
-    image_url TEXT DEFAULT '',
-    tags TEXT[] DEFAULT ARRAY[]::TEXT[]
-  );`);
-
-  await query(
-    "ALTER TABLE usina_posts ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT ARRAY[]::TEXT[]"
-  );
-
-  await query(`CREATE TABLE IF NOT EXISTS site_texts (
-    id SERIAL PRIMARY KEY,
-    slug TEXT UNIQUE NOT NULL,
-    titulo TEXT DEFAULT '',
-    contenido TEXT DEFAULT ''
-  );`);
-
-  await query(`CREATE TABLE IF NOT EXISTS site_sections (
-    section TEXT PRIMARY KEY,
-    data JSONB NOT NULL
-  );`);
-
-  await query(`CREATE TABLE IF NOT EXISTS faqs (
-    id SERIAL PRIMARY KEY,
-    question TEXT NOT NULL,
-    answer TEXT NOT NULL,
-    position INTEGER NOT NULL DEFAULT 0,
-    tags TEXT[] DEFAULT ARRAY[]::TEXT[]
-  );`);
-
-  await query(
-    "ALTER TABLE faqs ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT ARRAY[]::TEXT[]"
-  );
-
-  await query(`CREATE TABLE IF NOT EXISTS login_codes (
-    id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-    code TEXT NOT NULL,
-    expires_at TIMESTAMPTZ NOT NULL
-  );`);
-
-  const adminPassword = process.env.ADMIN_PASSWORD;
-  if (adminPassword) {
-    const passwordHash = await bcrypt.hash(adminPassword, 12);
-    await query(
-      `INSERT INTO users (email, password_hash, role)
-       VALUES ($1, $2, 'ADMIN')
-       ON CONFLICT (email) DO UPDATE SET password_hash = EXCLUDED.password_hash, role = 'ADMIN';`,
-      [config.adminEmail, passwordHash]
-    );
-  }
-
+function getSeedData() {
   const withTags = (item, defaultTags = []) => ({
     tags: defaultTags,
     ...item,
@@ -207,7 +197,7 @@ export async function initializeDatabase() {
       { id: "ilustracion", name: "Ilustración", pdfUrl: "" },
       { id: "medios-audiovisuales", name: "Medios Audiovisuales", pdfUrl: "" },
       { id: "profesorado", name: "Profesorado", pdfUrl: "" },
-      { id: "realizador", name: "Realizador en AV", pdfUrl: "" }
+      { id: "realizador", name: "Realizador en AV", pdfUrl: "" },
     ],
   };
 
@@ -222,7 +212,7 @@ export async function initializeDatabase() {
     logos: [
       { id: "malharro", src: "/malharrooficial/images/Logo_Malharro.svg", alt: "Escuela de Artes Visuales Martín Malharro" },
       { id: "educacion-artistica", src: "/malharrooficial/images/Logo_Educ_Art.svg", alt: "Educación artística" },
-      { id: "direccion-bsas", src: "/malharrooficial/images/Logo_Direcc_BsAs.svg", alt: "Dirección de Cultura" }
+      { id: "direccion-bsas", src: "/malharrooficial/images/Logo_Direcc_BsAs.svg", alt: "Dirección de Cultura" },
     ],
     quickLinks: [
       { id: "carreras", label: "Carreras", url: "#" },
@@ -230,38 +220,17 @@ export async function initializeDatabase() {
       { id: "estudiantes", label: "Estudiantes", url: "#" },
       { id: "agenda", label: "Agenda", url: "#" },
       { id: "talleres", label: "Talleres", url: "#" },
-      { id: "faq", label: "Preguntas frecuentes", url: "#" }
+      { id: "faq", label: "Preguntas frecuentes", url: "#" },
     ],
     address: "La Pampa 1619, Mar del Plata, Argentina. 7600",
     socials: [
       { id: "facebook", label: "Facebook", url: "https://www.facebook.com/avmalharro/", icon: "/malharrooficial/images/Icon_Facebook.svg" },
       { id: "instagram", label: "Instagram", url: "https://www.instagram.com/avmartinmalharro/?hl=es", icon: "/malharrooficial/images/Icon_Instagram.svg" },
       { id: "x", label: "X", url: "https://x.com/avmalharro", icon: "/malharrooficial/images/Icon_Twitter.svg" },
-      { id: "youtube", label: "YouTube", url: "https://www.youtube.com/@AVMartinMalharroOK", icon: "/malharrooficial/images/Icon_YT.svg" }
+      { id: "youtube", label: "YouTube", url: "https://www.youtube.com/@AVMartinMalharroOK", icon: "/malharrooficial/images/Icon_YT.svg" },
     ],
-    credits: "2025 © ESCUELA DE ARTES VISUALES MARTÍN A. MALHARRO | Sitio diseñado por alumn@s de la carrera de Diseño Gráfico 4ºA"
+    credits: "2025 © ESCUELA DE ARTES VISUALES MARTÍN A. MALHARRO | Sitio diseñado por alumn@s de la carrera de Diseño Gráfico 4ºA",
   };
-
-  await query(
-    `INSERT INTO site_sections (section, data)
-     VALUES ('navbar', $1)
-     ON CONFLICT (section) DO NOTHING;`,
-    [defaultNavbar]
-  );
-
-  await query(
-    `INSERT INTO site_sections (section, data)
-     VALUES ('careers', $1)
-     ON CONFLICT (section) DO NOTHING;`,
-    [defaultCareers]
-  );
-
-  await query(
-    `INSERT INTO site_sections (section, data)
-     VALUES ('footer', $1)
-     ON CONFLICT (section) DO NOTHING;`,
-    [defaultFooter]
-  );
 
   const textSeeds = [
     {
@@ -297,8 +266,290 @@ export async function initializeDatabase() {
     },
   ];
 
-  for (const seed of textSeeds) {
-    // Sequential inserts ensure deterministic ordering for seeds.
+  const carouselSlides = [
+    {
+      imageUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      imageDesktopUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      imageMobileUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      captionText: "Mostrá tu creatividad en la Malharro",
+      position: 1,
+    },
+    {
+      imageUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      imageDesktopUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      imageMobileUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      captionText: "Formación pública con identidad",
+      position: 2,
+    },
+    {
+      imageUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      imageDesktopUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      imageMobileUrl: "/malharrooficial/images/BANNER MUESTRA.png",
+      captionText: "Sumate a nuestra comunidad artística",
+      position: 3,
+    },
+  ];
+
+  const agendaEvents = [
+    {
+      titulo: "Taller de afiches",
+      descripcion: "por Coco Cerella",
+      fecha: "2025-10-24",
+      imageUrl: "/malharrooficial/images/CHARLA FEED.png",
+      tags: ["CHARLAS", "JORNADAS"],
+    },
+    {
+      titulo: "Aviso importante",
+      descripcion: "Reunión informativa de ingresantes",
+      fecha: "2025-11-10",
+      imageUrl: "/malharrooficial/images/AVISO uno.png",
+      tags: ["INGRESANTES", "INFORMES"],
+    },
+    {
+      titulo: "Encuentro creativo",
+      descripcion: "Jam de ilustración y medios audiovisuales",
+      fecha: "2025-12-02",
+      imageUrl: "/malharrooficial/images/AVISO dos.png",
+      tags: ["JORNADAS", "COMUNIDAD"],
+    },
+  ];
+
+  const usinaPosts = [
+    {
+      titulo: "Historias que inspiran",
+      texto: "Nuestros egresados comparten proyectos que transforman la comunidad.",
+      imageUrl: "/malharrooficial/images/CHARLA FEED.png",
+      tags: ["Historias", "Destacados"],
+    },
+    {
+      titulo: "Proyectos interdisciplinarios",
+      texto: "Diseño, ilustración y medios audiovisuales se unen para crear experiencias únicas.",
+      imageUrl: "/malharrooficial/images/AVISO uno.png",
+      tags: ["Proyectos", "Colaboraciones"],
+    },
+  ];
+
+  const faqs = [
+    {
+      question: "¿Dónde queda la Malharro?",
+      answer:
+        "La Escuela se encuentra en la ciudad de Mar del Plata. Ubicada en la esquina de Luro y La Pampa, frente a la Terminal de micros.<br><br><iframe src=\"https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3144.449087550747!2d-57.56621552511716!3d-37.98998424412818!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x9584d951f12bae1f%3A0x7b0eaea299a69b09!2sEscuela%20de%20Artes%20Visuales%20M.A%20Malharro!5e0!3m2!1ses-419!2sar!4v1756941987999!5m2!1ses-419!2sar\" width=\"600\" height=\"450\" style=\"border:0;\" allowfullscreen=\"\" loading=\"lazy\" referrerpolicy=\"no-referrer-when-downgrade\"></iframe>",
+      position: 1,
+      tags: ["Ubicación", "Ingreso"],
+    },
+    {
+      question: "¿Se puede cursar más de una carrera a la vez?",
+      answer:
+        "Consultar con el equipo académico permite evaluar la carga horaria y compatibilidad de materias para cada caso en particular.",
+      position: 2,
+      tags: ["Académico", "Orientación"],
+    },
+    {
+      question: "¿Cuándo comienzan las clases?",
+      answer:
+        "El ciclo lectivo suele comenzar en abril y se divide en dos cuatrimestres. El calendario académico se publica en el sitio web institucional y se informa a través de los canales oficiales.",
+      position: 3,
+      tags: ["Calendario", "Clases"],
+    },
+  ];
+
+  return {
+    defaultNavbar,
+    defaultCareers,
+    defaultFooter,
+    textSeeds,
+    carouselSlides,
+    agendaEvents,
+    usinaPosts,
+    faqs,
+  };
+}
+
+async function seedMemoryStore() {
+  resetMemoryStore();
+  const seeds = getSeedData();
+
+  if (config.adminPassword) {
+    const passwordHash = await bcrypt.hash(config.adminPassword, 12);
+    memoryStore.users.push({
+      id: nextMemoryId("users"),
+      email: config.adminEmail,
+      password_hash: passwordHash,
+      role: "ADMIN",
+    });
+  }
+
+  memoryStore.siteSections.set("navbar", seeds.defaultNavbar);
+  memoryStore.siteSections.set("careers", seeds.defaultCareers);
+  memoryStore.siteSections.set("footer", seeds.defaultFooter);
+
+  for (const seed of seeds.textSeeds) {
+    memoryStore.siteTexts.push({
+      id: nextMemoryId("siteTexts"),
+      slug: seed.slug,
+      titulo: seed.titulo,
+      contenido: seed.contenido,
+    });
+  }
+
+  for (const slide of seeds.carouselSlides) {
+    memoryStore.carouselSlides.push({
+      id: nextMemoryId("carouselSlides"),
+      image_url: slide.imageUrl,
+      image_desktop_url: slide.imageDesktopUrl,
+      image_mobile_url: slide.imageMobileUrl,
+      caption_text: slide.captionText,
+      position: slide.position,
+    });
+  }
+
+  for (const event of seeds.agendaEvents) {
+    memoryStore.agendaEvents.push({
+      id: nextMemoryId("agendaEvents"),
+      titulo: event.titulo,
+      descripcion: event.descripcion,
+      fecha: event.fecha,
+      image_url: event.imageUrl,
+      tags: [...event.tags],
+    });
+  }
+
+  for (const post of seeds.usinaPosts) {
+    memoryStore.usinaPosts.push({
+      id: nextMemoryId("usinaPosts"),
+      titulo: post.titulo,
+      texto: post.texto,
+      image_url: post.imageUrl,
+      tags: [...post.tags],
+    });
+  }
+
+  for (const faq of seeds.faqs) {
+    memoryStore.faqs.push({
+      id: nextMemoryId("faqs"),
+      question: faq.question,
+      answer: faq.answer,
+      position: faq.position,
+      tags: [...faq.tags],
+    });
+  }
+}
+
+async function runMigrations() {
+  if (usingInMemory) {
+    await seedMemoryStore();
+    return;
+  }
+
+  await query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'ADMIN'
+  );`);
+
+  await query(`CREATE TABLE IF NOT EXISTS carousel_slides (
+    id SERIAL PRIMARY KEY,
+    image_url TEXT NOT NULL,
+    image_desktop_url TEXT DEFAULT '',
+    image_mobile_url TEXT DEFAULT '',
+    caption_text TEXT DEFAULT '',
+    position INTEGER DEFAULT 0
+  );`);
+
+  await query(
+    "ALTER TABLE carousel_slides ADD COLUMN IF NOT EXISTS image_desktop_url TEXT DEFAULT ''"
+  );
+  await query(
+    "ALTER TABLE carousel_slides ADD COLUMN IF NOT EXISTS image_mobile_url TEXT DEFAULT ''"
+  );
+
+  await query(`CREATE TABLE IF NOT EXISTS agenda_events (
+    id SERIAL PRIMARY KEY,
+    titulo TEXT NOT NULL,
+    descripcion TEXT DEFAULT '',
+    fecha DATE,
+    image_url TEXT DEFAULT '',
+    tags TEXT[] DEFAULT ARRAY[]::TEXT[]
+  );`);
+
+  await query(`CREATE TABLE IF NOT EXISTS usina_posts (
+    id SERIAL PRIMARY KEY,
+    titulo TEXT NOT NULL,
+    texto TEXT DEFAULT '',
+    image_url TEXT DEFAULT '',
+    tags TEXT[] DEFAULT ARRAY[]::TEXT[]
+  );`);
+
+  await query(
+    "ALTER TABLE usina_posts ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT ARRAY[]::TEXT[]"
+  );
+
+  await query(`CREATE TABLE IF NOT EXISTS site_texts (
+    id SERIAL PRIMARY KEY,
+    slug TEXT UNIQUE NOT NULL,
+    titulo TEXT DEFAULT '',
+    contenido TEXT DEFAULT ''
+  );`);
+
+  await query(`CREATE TABLE IF NOT EXISTS site_sections (
+    section TEXT PRIMARY KEY,
+    data JSONB NOT NULL
+  );`);
+
+  await query(`CREATE TABLE IF NOT EXISTS faqs (
+    id SERIAL PRIMARY KEY,
+    question TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    tags TEXT[] DEFAULT ARRAY[]::TEXT[]
+  );`);
+
+  await query(
+    "ALTER TABLE faqs ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT ARRAY[]::TEXT[]"
+  );
+
+  await query(`CREATE TABLE IF NOT EXISTS login_codes (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    code TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+  );`);
+
+  if (config.adminPassword) {
+    const passwordHash = await bcrypt.hash(config.adminPassword, 12);
+    await query(
+      `INSERT INTO users (email, password_hash, role)
+       VALUES ($1, $2, 'ADMIN')
+       ON CONFLICT (email) DO UPDATE SET password_hash = EXCLUDED.password_hash, role = 'ADMIN';`,
+      [config.adminEmail, passwordHash]
+    );
+  }
+
+  const seeds = getSeedData();
+
+  await query(
+    `INSERT INTO site_sections (section, data)
+     VALUES ('navbar', $1)
+     ON CONFLICT (section) DO NOTHING;`,
+    [seeds.defaultNavbar]
+  );
+
+  await query(
+    `INSERT INTO site_sections (section, data)
+     VALUES ('careers', $1)
+     ON CONFLICT (section) DO NOTHING;`,
+    [seeds.defaultCareers]
+  );
+
+  await query(
+    `INSERT INTO site_sections (section, data)
+     VALUES ('footer', $1)
+     ON CONFLICT (section) DO NOTHING;`,
+    [seeds.defaultFooter]
+  );
+
+  for (const seed of seeds.textSeeds) {
     await query(
       `INSERT INTO site_texts (slug, titulo, contenido)
        VALUES ($1, $2, $3)
@@ -309,45 +560,92 @@ export async function initializeDatabase() {
 
   const sliderCount = await query(`SELECT COUNT(*) AS count FROM carousel_slides`);
   if (Number(sliderCount.rows[0]?.count || 0) === 0) {
-    await query(
-      `INSERT INTO carousel_slides (image_url, image_desktop_url, image_mobile_url, caption_text, position) VALUES
-        ('/malharrooficial/images/BANNER MUESTRA.png', '/malharrooficial/images/BANNER MUESTRA.png', '/malharrooficial/images/BANNER MUESTRA.png', 'Mostrá tu creatividad en la Malharro', 1),
-        ('/malharrooficial/images/BANNER MUESTRA.png', '/malharrooficial/images/BANNER MUESTRA.png', '/malharrooficial/images/BANNER MUESTRA.png', 'Formación pública con identidad', 2),
-        ('/malharrooficial/images/BANNER MUESTRA.png', '/malharrooficial/images/BANNER MUESTRA.png', '/malharrooficial/images/BANNER MUESTRA.png', 'Sumate a nuestra comunidad artística', 3)`
-    );
+    for (const slide of seeds.carouselSlides) {
+      await query(
+        `INSERT INTO carousel_slides (image_url, image_desktop_url, image_mobile_url, caption_text, position)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          slide.imageUrl,
+          slide.imageDesktopUrl,
+          slide.imageMobileUrl,
+          slide.captionText,
+          slide.position,
+        ]
+      );
+    }
   }
 
   const agendaCount = await query(`SELECT COUNT(*) AS count FROM agenda_events`);
   if (Number(agendaCount.rows[0]?.count || 0) === 0) {
-    await query(
-      `INSERT INTO agenda_events (titulo, descripcion, fecha, image_url, tags) VALUES
-        ('Taller de afiches', 'por Coco Cerella', '2025-10-24', '/malharrooficial/images/CHARLA FEED.png', ARRAY['CHARLAS','JORNADAS']),
-        ('Aviso importante', 'Reunión informativa de ingresantes', '2025-11-10', '/malharrooficial/images/AVISO uno.png', ARRAY['INGRESANTES','INFORMES']),
-        ('Encuentro creativo', 'Jam de ilustración y medios audiovisuales', '2025-12-02', '/malharrooficial/images/AVISO dos.png', ARRAY['JORNADAS','COMUNIDAD'])`
-    );
+    for (const event of seeds.agendaEvents) {
+      await query(
+        `INSERT INTO agenda_events (titulo, descripcion, fecha, image_url, tags)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [event.titulo, event.descripcion, event.fecha, event.imageUrl, event.tags]
+      );
+    }
   }
 
   const usinaCount = await query(`SELECT COUNT(*) AS count FROM usina_posts`);
   if (Number(usinaCount.rows[0]?.count || 0) === 0) {
-    await query(
-      `INSERT INTO usina_posts (titulo, texto, image_url, tags) VALUES
-        ('Historias que inspiran', 'Nuestros egresados comparten proyectos que transforman la comunidad.', '/malharrooficial/images/CHARLA FEED.png', ARRAY['Historias','Destacados']),
-        ('Proyectos interdisciplinarios', 'Diseño, ilustración y medios audiovisuales se unen para crear experiencias únicas.', '/malharrooficial/images/AVISO uno.png', ARRAY['Proyectos','Colaboraciones'])`
-    );
+    for (const post of seeds.usinaPosts) {
+      await query(
+        `INSERT INTO usina_posts (titulo, texto, image_url, tags)
+         VALUES ($1, $2, $3, $4)`,
+        [post.titulo, post.texto, post.imageUrl, post.tags]
+      );
+    }
   }
 
   const faqCount = await query(`SELECT COUNT(*) AS count FROM faqs`);
   if (Number(faqCount.rows[0]?.count || 0) === 0) {
-    await query(
-      `INSERT INTO faqs (question, answer, position, tags) VALUES
-        ('¿Dónde queda la Malharro?', 'La Escuela se encuentra en la ciudad de Mar del Plata. Ubicada en la esquina de Luro y La Pampa, frente a la Terminal de micros.<br><br><iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3144.449087550747!2d-57.56621552511716!3d-37.98998424412818!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x9584d951f12bae1f%3A0x7b0eaea299a69b09!2sEscuela%20de%20Artes%20Visuales%20M.A%20Malharro!5e0!3m2!1ses-419!2sar!4v1756941987999!5m2!1ses-419!2sar" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>', 1, ARRAY['Ubicación','Ingreso']),
-        ('¿Se puede cursar más de una carrera a la vez?', 'Consultar con el equipo académico permite evaluar la carga horaria y compatibilidad de materias para cada caso en particular.', 2, ARRAY['Académico','Orientación']),
-        ('¿Cuándo comienzan las clases?', 'El ciclo lectivo suele comenzar en abril y se divide en dos cuatrimestres. El calendario académico se publica en el sitio web institucional y se informa a través de los canales oficiales.', 3, ARRAY['Calendario','Clases'])
-      `
-    );
+    for (const faq of seeds.faqs) {
+      await query(
+        `INSERT INTO faqs (question, answer, position, tags)
+         VALUES ($1, $2, $3, $4)`,
+        [faq.question, faq.answer, faq.position, faq.tags]
+      );
+    }
   }
 
   await query(`DELETE FROM site_texts WHERE slug = 'home_agenda_cta_url'`);
+}
+
+export async function initializeDatabase() {
+  try {
+    await runMigrations();
+  } catch (error) {
+    if (!usingInMemory && isConnectionError(error)) {
+      console.warn(
+        "Could not connect to the configured PostgreSQL database. Falling back to an in-memory database."
+      );
+      usingInMemory = true;
+      if (pool && typeof pool.end === "function") {
+        try {
+          await pool.end();
+        } catch (endError) {
+          console.warn("Failed to close PostgreSQL pool during fallback", endError);
+        }
+      }
+      pool = null;
+      await runMigrations();
+    } else {
+      console.error("Failed to initialize database", error);
+      throw error;
+    }
+  }
+}
+
+export function isUsingInMemoryDatabase() {
+  return usingInMemory;
+}
+
+export function getMemoryStore() {
+  return memoryStore;
+}
+
+export function allocateMemoryId(table) {
+  return nextMemoryId(table);
 }
 
 export default pool;

--- a/backend/src/routes/agenda.routes.js
+++ b/backend/src/routes/agenda.routes.js
@@ -1,17 +1,18 @@
 import express from "express";
 import { authenticate } from "../middleware/auth.js";
-import { query } from "../db.js";
+import {
+  getAgendaEvents,
+  createAgendaEvent,
+  updateAgendaEvent,
+  deleteAgendaEvent,
+} from "../services/dataStore.js";
 
 const router = express.Router();
 
 router.get("/", async (_req, res) => {
   try {
-    const { rows } = await query(
-      `SELECT id, titulo, descripcion, fecha, image_url AS "imageUrl", tags
-       FROM agenda_events
-       ORDER BY fecha DESC NULLS LAST, id DESC`
-    );
-    return res.json({ items: rows });
+    const items = await getAgendaEvents();
+    return res.json({ items });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo obtener la agenda" });
@@ -25,13 +26,14 @@ router.post("/", authenticate, async (req, res) => {
   }
 
   try {
-    const { rows } = await query(
-      `INSERT INTO agenda_events (titulo, descripcion, fecha, image_url, tags)
-       VALUES ($1, $2, $3, $4, $5)
-       RETURNING id`,
-      [titulo, descripcion || "", fecha || null, imageUrl || "", Array.isArray(tags) ? tags : []]
-    );
-    return res.status(201).json({ id: rows[0].id });
+    const { id } = await createAgendaEvent({
+      titulo,
+      descripcion,
+      fecha,
+      imageUrl,
+      tags: Array.isArray(tags) ? tags : [],
+    });
+    return res.status(201).json({ id });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo crear el evento" });
@@ -42,16 +44,13 @@ router.put("/:id", authenticate, async (req, res) => {
   const { id } = req.params;
   const { titulo, descripcion, fecha, imageUrl, tags } = req.body;
   try {
-    await query(
-      `UPDATE agenda_events
-       SET titulo = COALESCE($1, titulo),
-           descripcion = COALESCE($2, descripcion),
-           fecha = COALESCE($3, fecha),
-           image_url = COALESCE($4, image_url),
-           tags = COALESCE($5, tags)
-       WHERE id = $6`,
-      [titulo, descripcion, fecha, imageUrl, Array.isArray(tags) ? tags : null, id]
-    );
+    await updateAgendaEvent(id, {
+      titulo,
+      descripcion,
+      fecha,
+      imageUrl,
+      tags: Array.isArray(tags) ? tags : undefined,
+    });
     return res.json({ message: "Evento actualizado" });
   } catch (error) {
     console.error(error);
@@ -62,7 +61,7 @@ router.put("/:id", authenticate, async (req, res) => {
 router.delete("/:id", authenticate, async (req, res) => {
   const { id } = req.params;
   try {
-    await query("DELETE FROM agenda_events WHERE id = $1", [id]);
+    await deleteAgendaEvent(id);
     return res.json({ message: "Evento eliminado" });
   } catch (error) {
     console.error(error);

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -2,7 +2,13 @@ import express from "express";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { config } from "../config.js";
-import { query } from "../db.js";
+import {
+  findUserByEmail,
+  createLoginCode,
+  findRecentLoginCodes,
+  deleteLoginCodesByUser,
+  findUserById,
+} from "../services/dataStore.js";
 import { sendVerificationCode } from "../services/email.js";
 import { authenticate } from "../middleware/auth.js";
 
@@ -19,8 +25,7 @@ router.post("/login", async (req, res) => {
   }
 
   try {
-    const { rows } = await query("SELECT * FROM users WHERE email = $1 LIMIT 1", [email]);
-    const user = rows[0];
+    const user = await findUserByEmail(email);
     if (!user || user.email !== config.adminEmail) {
       return res.status(401).json({ message: "Credenciales inválidas" });
     }
@@ -32,10 +37,7 @@ router.post("/login", async (req, res) => {
 
     const code = generateCode();
     const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
-    await query(
-      `INSERT INTO login_codes (user_id, code, expires_at) VALUES ($1, $2, $3)`,
-      [user.id, code, expiresAt]
-    );
+    await createLoginCode(user.id, code, expiresAt);
 
     try {
       await sendVerificationCode(user.email, code);
@@ -58,16 +60,12 @@ router.post("/verify", async (req, res) => {
   }
 
   try {
-    const { rows } = await query("SELECT * FROM users WHERE email = $1 LIMIT 1", [email]);
-    const user = rows[0];
+    const user = await findUserByEmail(email);
     if (!user || user.email !== config.adminEmail) {
       return res.status(401).json({ message: "Código inválido" });
     }
 
-    const { rows: codes } = await query(
-      `SELECT * FROM login_codes WHERE user_id = $1 ORDER BY expires_at DESC LIMIT 5`,
-      [user.id]
-    );
+    const codes = await findRecentLoginCodes(user.id, 5);
 
     const now = new Date();
     const match = codes.find((entry) => entry.code === code && new Date(entry.expires_at) > now);
@@ -76,7 +74,7 @@ router.post("/verify", async (req, res) => {
       return res.status(401).json({ message: "Código inválido o expirado" });
     }
 
-    await query(`DELETE FROM login_codes WHERE user_id = $1`, [user.id]);
+    await deleteLoginCodesByUser(user.id);
 
     const token = jwt.sign({ id: user.id, email: user.email, role: user.role }, config.jwtSecret, {
       expiresIn: config.jwtExpiresIn,
@@ -94,8 +92,7 @@ router.post("/verify", async (req, res) => {
 
 router.get("/me", authenticate, async (req, res) => {
   try {
-    const { rows } = await query("SELECT id, email, role FROM users WHERE id = $1", [req.user.id]);
-    const user = rows[0];
+    const user = await findUserById(req.user.id);
     if (!user) {
       return res.status(404).json({ message: "Usuario no encontrado" });
     }

--- a/backend/src/routes/carousel.routes.js
+++ b/backend/src/routes/carousel.routes.js
@@ -1,23 +1,19 @@
 import express from "express";
 import { authenticate } from "../middleware/auth.js";
-import { query } from "../db.js";
+import {
+  getCarouselSlides,
+  getNextCarouselPosition,
+  createCarouselSlide,
+  updateCarouselSlide,
+  deleteCarouselSlide,
+} from "../services/dataStore.js";
 
 const router = express.Router();
 
 router.get("/", async (_req, res) => {
   try {
-    const { rows } = await query(
-      `SELECT
-         id,
-         COALESCE(NULLIF(image_desktop_url, ''), image_url) AS "imageDesktopUrl",
-         COALESCE(NULLIF(image_mobile_url, ''), image_url) AS "imageMobileUrl",
-         image_url AS "imageUrl",
-         caption_text AS "captionText",
-         position
-       FROM carousel_slides
-       ORDER BY position ASC, id ASC`
-    );
-    return res.json({ items: rows });
+    const items = await getCarouselSlides();
+    return res.json({ items });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo obtener el carrusel" });
@@ -37,19 +33,19 @@ router.post("/", authenticate, async (req, res) => {
   try {
     let nextPosition = Number(position);
     if (!Number.isFinite(nextPosition)) {
-      const { rows } = await query("SELECT COALESCE(MAX(position), 0) + 1 AS next FROM carousel_slides");
-      nextPosition = Number(rows[0]?.next || 1);
+      nextPosition = await getNextCarouselPosition();
     } else {
       nextPosition = Number(nextPosition);
     }
 
-    const { rows } = await query(
-      `INSERT INTO carousel_slides (image_url, image_desktop_url, image_mobile_url, caption_text, position)
-       VALUES ($1, $2, $3, $4, $5)
-       RETURNING id`,
-      [fallback, desktop, mobile, captionText || "", nextPosition]
-    );
-    return res.status(201).json({ id: rows[0].id });
+    const { id: createdId } = await createCarouselSlide({
+      imageUrl: fallback,
+      imageDesktopUrl: desktop,
+      imageMobileUrl: mobile,
+      captionText: captionText || "",
+      position: nextPosition,
+    });
+    return res.status(201).json({ id: createdId });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo crear la diapositiva" });
@@ -66,16 +62,13 @@ router.put("/:id", authenticate, async (req, res) => {
   const normalizedPosition = Number.isFinite(Number(position)) ? Number(position) : null;
 
   try {
-    await query(
-      `UPDATE carousel_slides
-         SET image_url = COALESCE($1, image_url),
-             image_desktop_url = COALESCE($2, image_desktop_url),
-             image_mobile_url = COALESCE($3, image_mobile_url),
-             caption_text = COALESCE($4, caption_text),
-             position = COALESCE($5, position)
-       WHERE id = $6`,
-      [fallback, desktop, mobile, captionText, normalizedPosition, id]
-    );
+    await updateCarouselSlide(id, {
+      imageUrl: fallback,
+      imageDesktopUrl: desktop,
+      imageMobileUrl: mobile,
+      captionText,
+      position: normalizedPosition,
+    });
     return res.json({ message: "Diapositiva actualizada" });
   } catch (error) {
     console.error(error);
@@ -86,7 +79,7 @@ router.put("/:id", authenticate, async (req, res) => {
 router.delete("/:id", authenticate, async (req, res) => {
   const { id } = req.params;
   try {
-    await query("DELETE FROM carousel_slides WHERE id = $1", [id]);
+    await deleteCarouselSlide(id);
     return res.json({ message: "Diapositiva eliminada" });
   } catch (error) {
     console.error(error);

--- a/backend/src/routes/faqs.routes.js
+++ b/backend/src/routes/faqs.routes.js
@@ -1,17 +1,19 @@
 import express from "express";
 import { authenticate } from "../middleware/auth.js";
-import { query } from "../db.js";
+import {
+  getFaqs,
+  getNextFaqPosition,
+  createFaq,
+  updateFaq,
+  deleteFaq,
+} from "../services/dataStore.js";
 
 const router = express.Router();
 
 router.get("/", async (_req, res) => {
   try {
-    const { rows } = await query(
-      `SELECT id, question, answer, position, tags
-       FROM faqs
-       ORDER BY position ASC, id ASC`
-    );
-    return res.json({ items: rows });
+    const items = await getFaqs();
+    return res.json({ items });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudieron obtener las preguntas frecuentes" });
@@ -39,18 +41,17 @@ router.post("/", authenticate, async (req, res) => {
   try {
     let finalPosition = Number.isFinite(Number(position)) ? Number(position) : null;
     if (finalPosition === null) {
-      const { rows } = await query(`SELECT COALESCE(MAX(position), 0) + 1 AS next FROM faqs`);
-      finalPosition = Number(rows[0]?.next || 1);
+      finalPosition = await getNextFaqPosition();
     }
 
-    const { rows } = await query(
-      `INSERT INTO faqs (question, answer, position, tags)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id, question, answer, position, tags`,
-      [question.trim(), answer.trim(), finalPosition, normalizedTags]
-    );
+    const created = await createFaq({
+      question: question.trim(),
+      answer: answer.trim(),
+      position: finalPosition,
+      tags: normalizedTags,
+    });
 
-    return res.status(201).json(rows[0]);
+    return res.status(201).json(created);
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo crear la pregunta frecuente" });
@@ -65,24 +66,20 @@ router.put("/:id", authenticate, async (req, res) => {
     return res.status(400).json({ message: "No hay cambios para aplicar" });
   }
 
-  const updates = [];
-  const values = [];
+  const updatePayload = {};
 
   if (typeof question === "string") {
-    updates.push(`question = $${updates.length + 1}`);
-    values.push(question.trim());
+    updatePayload.question = question.trim();
   }
 
   if (typeof answer === "string") {
-    updates.push(`answer = $${updates.length + 1}`);
-    values.push(answer.trim());
+    updatePayload.answer = answer.trim();
   }
 
   if (typeof position !== "undefined") {
     const parsed = Number(position);
     if (Number.isFinite(parsed)) {
-      updates.push(`position = $${updates.length + 1}`);
-      values.push(parsed);
+      updatePayload.position = parsed;
     }
   }
 
@@ -94,26 +91,15 @@ router.put("/:id", authenticate, async (req, res) => {
     if (!normalizedTags.length) {
       return res.status(400).json({ message: "Agregá al menos una etiqueta" });
     }
-    updates.push(`tags = $${updates.length + 1}`);
-    values.push(normalizedTags);
+    updatePayload.tags = normalizedTags;
   }
 
-  if (!updates.length) {
+  if (!Object.keys(updatePayload).length) {
     return res.status(400).json({ message: "No hay cambios para aplicar" });
   }
 
-  values.push(id);
-
   try {
-    const { rows } = await query(
-      `UPDATE faqs
-       SET ${updates.join(", ")}
-       WHERE id = $${updates.length + 1}
-       RETURNING id, question, answer, position, tags`,
-      values
-    );
-
-    const item = rows[0];
+    const item = await updateFaq(id, updatePayload);
     if (!item) {
       return res.status(404).json({ message: "Pregunta frecuente no encontrada" });
     }
@@ -128,8 +114,8 @@ router.put("/:id", authenticate, async (req, res) => {
 router.delete("/:id", authenticate, async (req, res) => {
   const { id } = req.params;
   try {
-    const { rowCount } = await query(`DELETE FROM faqs WHERE id = $1`, [id]);
-    if (!rowCount) {
+    const removed = await deleteFaq(id);
+    if (!removed) {
       return res.status(404).json({ message: "Pregunta frecuente no encontrada" });
     }
     return res.json({ message: "Pregunta frecuente eliminada" });

--- a/backend/src/routes/sections.routes.js
+++ b/backend/src/routes/sections.routes.js
@@ -1,18 +1,13 @@
 import express from "express";
 import { authenticate } from "../middleware/auth.js";
-import { query } from "../db.js";
+import { getSiteSection, upsertSiteSection } from "../services/dataStore.js";
 
 const router = express.Router();
-
-async function getSection(section) {
-  const { rows } = await query(`SELECT data FROM site_sections WHERE section = $1 LIMIT 1`, [section]);
-  return rows[0]?.data || null;
-}
 
 router.get("/:section", async (req, res) => {
   const { section } = req.params;
   try {
-    const data = await getSection(section);
+    const data = await getSiteSection(section);
     if (!data) {
       return res.status(404).json({ message: "Sección no encontrada" });
     }
@@ -27,12 +22,7 @@ router.put("/:section", authenticate, async (req, res) => {
   const { section } = req.params;
   const data = req.body;
   try {
-    await query(
-      `INSERT INTO site_sections (section, data) VALUES ($1, $2)
-       ON CONFLICT (section) DO UPDATE SET data = EXCLUDED.data`,
-      [section, data]
-    );
-    const updated = await getSection(section);
+    const updated = await upsertSiteSection(section, data);
     return res.json({ section, data: updated });
   } catch (error) {
     console.error(error);

--- a/backend/src/routes/texts.routes.js
+++ b/backend/src/routes/texts.routes.js
@@ -1,17 +1,17 @@
 import express from "express";
 import { authenticate } from "../middleware/auth.js";
-import { query } from "../db.js";
+import {
+  getSiteTexts,
+  getSiteTextBySlug,
+  upsertSiteText,
+} from "../services/dataStore.js";
 
 const router = express.Router();
 
 router.get("/", async (_req, res) => {
   try {
-    const { rows } = await query(
-      `SELECT id, slug, titulo, contenido
-       FROM site_texts
-       ORDER BY slug ASC`
-    );
-    return res.json({ items: rows });
+    const items = await getSiteTexts();
+    return res.json({ items });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo obtener los textos" });
@@ -21,11 +21,7 @@ router.get("/", async (_req, res) => {
 router.get("/:slug", async (req, res) => {
   const { slug } = req.params;
   try {
-    const { rows } = await query(
-      `SELECT id, slug, titulo, contenido FROM site_texts WHERE slug = $1 LIMIT 1`,
-      [slug]
-    );
-    const item = rows[0];
+    const item = await getSiteTextBySlug(slug);
     if (!item) {
       return res.status(404).json({ message: "Texto no encontrado" });
     }
@@ -40,16 +36,7 @@ router.put("/:slug", authenticate, async (req, res) => {
   const { slug } = req.params;
   const { titulo, contenido } = req.body;
   try {
-    const { rowCount } = await query(
-      `UPDATE site_texts SET titulo = COALESCE($1, titulo), contenido = COALESCE($2, contenido) WHERE slug = $3`,
-      [titulo, contenido, slug]
-    );
-    if (!rowCount) {
-      await query(
-        `INSERT INTO site_texts (slug, titulo, contenido) VALUES ($1, $2, $3)`,
-        [slug, titulo || "", contenido || ""]
-      );
-    }
+    await upsertSiteText(slug, titulo, contenido);
     return res.json({ message: "Texto actualizado" });
   } catch (error) {
     console.error(error);

--- a/backend/src/routes/usina.routes.js
+++ b/backend/src/routes/usina.routes.js
@@ -1,17 +1,18 @@
 import express from "express";
 import { authenticate } from "../middleware/auth.js";
-import { query } from "../db.js";
+import {
+  getUsinaPosts,
+  createUsinaPost,
+  updateUsinaPost,
+  deleteUsinaPost,
+} from "../services/dataStore.js";
 
 const router = express.Router();
 
 router.get("/", async (_req, res) => {
   try {
-    const { rows } = await query(
-      `SELECT id, titulo, texto, image_url AS "imageUrl", tags
-       FROM usina_posts
-       ORDER BY id DESC`
-    );
-    return res.json({ items: rows });
+    const items = await getUsinaPosts();
+    return res.json({ items });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo obtener la usina" });
@@ -37,13 +38,13 @@ router.post("/", authenticate, async (req, res) => {
   }
 
   try {
-    const { rows } = await query(
-      `INSERT INTO usina_posts (titulo, texto, image_url, tags)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id`,
-      [titulo, texto || "", imageUrl || "", normalizedTags]
-    );
-    return res.status(201).json({ id: rows[0].id });
+    const { id } = await createUsinaPost({
+      titulo,
+      texto,
+      imageUrl,
+      tags: normalizedTags,
+    });
+    return res.status(201).json({ id });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: "No se pudo crear el contenido" });
@@ -64,15 +65,12 @@ router.put("/:id", authenticate, async (req, res) => {
     }
   }
   try {
-    await query(
-      `UPDATE usina_posts
-       SET titulo = COALESCE($1, titulo),
-           texto = COALESCE($2, texto),
-           image_url = COALESCE($3, image_url),
-           tags = COALESCE($4, tags)
-       WHERE id = $5`,
-      [titulo, texto, imageUrl, normalizedTags, id]
-    );
+    await updateUsinaPost(id, {
+      titulo,
+      texto,
+      imageUrl,
+      tags: normalizedTags,
+    });
     return res.json({ message: "Contenido actualizado" });
   } catch (error) {
     console.error(error);
@@ -83,7 +81,7 @@ router.put("/:id", authenticate, async (req, res) => {
 router.delete("/:id", authenticate, async (req, res) => {
   const { id } = req.params;
   try {
-    await query("DELETE FROM usina_posts WHERE id = $1", [id]);
+    await deleteUsinaPost(id);
     return res.json({ message: "Contenido eliminado" });
   } catch (error) {
     console.error(error);

--- a/backend/src/services/dataStore.js
+++ b/backend/src/services/dataStore.js
@@ -1,0 +1,645 @@
+import {
+  query,
+  isUsingInMemoryDatabase,
+  getMemoryStore,
+  allocateMemoryId,
+} from "../db.js";
+
+function cloneTags(tags) {
+  return Array.isArray(tags) ? [...tags] : [];
+}
+
+function sortByPositionAndId(items) {
+  return [...items].sort((a, b) => {
+    const positionA = Number(a.position) || 0;
+    const positionB = Number(b.position) || 0;
+    if (positionA !== positionB) {
+      return positionA - positionB;
+    }
+    return Number(a.id) - Number(b.id);
+  });
+}
+
+function sortByDateDesc(items, accessor) {
+  return [...items].sort((a, b) => {
+    const valueA = accessor(a);
+    const valueB = accessor(b);
+    if (valueA === valueB) {
+      return Number(b.id) - Number(a.id);
+    }
+    if (valueA === null) return 1;
+    if (valueB === null) return -1;
+    return valueB - valueA;
+  });
+}
+
+// Carousel helpers
+export async function getCarouselSlides() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const slides = sortByPositionAndId(store.carouselSlides);
+    return slides.map((slide) => ({
+      id: slide.id,
+      imageDesktopUrl: slide.image_desktop_url || slide.image_url,
+      imageMobileUrl: slide.image_mobile_url || slide.image_url,
+      imageUrl: slide.image_url,
+      captionText: slide.caption_text || "",
+      position: slide.position,
+    }));
+  }
+
+  const { rows } = await query(
+    `SELECT
+       id,
+       COALESCE(NULLIF(image_desktop_url, ''), image_url) AS "imageDesktopUrl",
+       COALESCE(NULLIF(image_mobile_url, ''), image_url) AS "imageMobileUrl",
+       image_url AS "imageUrl",
+       caption_text AS "captionText",
+       position
+     FROM carousel_slides
+     ORDER BY position ASC, id ASC`
+  );
+  return rows;
+}
+
+export async function getNextCarouselPosition() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const maxPosition = store.carouselSlides.reduce((acc, slide) => {
+      const value = Number(slide.position) || 0;
+      return value > acc ? value : acc;
+    }, 0);
+    return maxPosition + 1;
+  }
+
+  const { rows } = await query("SELECT COALESCE(MAX(position), 0) + 1 AS next FROM carousel_slides");
+  return Number(rows[0]?.next || 1);
+}
+
+export async function createCarouselSlide({
+  imageUrl,
+  imageDesktopUrl,
+  imageMobileUrl,
+  captionText,
+  position,
+}) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const id = allocateMemoryId("carouselSlides");
+    store.carouselSlides.push({
+      id,
+      image_url: imageUrl,
+      image_desktop_url: imageDesktopUrl || imageUrl,
+      image_mobile_url: imageMobileUrl || imageUrl,
+      caption_text: captionText || "",
+      position,
+    });
+    return { id };
+  }
+
+  const { rows } = await query(
+    `INSERT INTO carousel_slides (image_url, image_desktop_url, image_mobile_url, caption_text, position)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id`,
+    [imageUrl, imageDesktopUrl, imageMobileUrl, captionText, position]
+  );
+  return rows[0];
+}
+
+export async function updateCarouselSlide(id, { imageUrl, imageDesktopUrl, imageMobileUrl, captionText, position }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const slide = store.carouselSlides.find((item) => Number(item.id) === Number(id));
+    if (!slide) {
+      return false;
+    }
+
+    if (typeof imageUrl === "string") {
+      slide.image_url = imageUrl;
+    }
+    if (typeof imageDesktopUrl === "string") {
+      slide.image_desktop_url = imageDesktopUrl;
+    }
+    if (typeof imageMobileUrl === "string") {
+      slide.image_mobile_url = imageMobileUrl;
+    }
+    if (typeof captionText === "string") {
+      slide.caption_text = captionText;
+    }
+    if (Number.isFinite(position)) {
+      slide.position = Number(position);
+    }
+    return true;
+  }
+
+  await query(
+    `UPDATE carousel_slides
+       SET image_url = COALESCE($1, image_url),
+           image_desktop_url = COALESCE($2, image_desktop_url),
+           image_mobile_url = COALESCE($3, image_mobile_url),
+           caption_text = COALESCE($4, caption_text),
+           position = COALESCE($5, position)
+     WHERE id = $6`,
+    [imageUrl, imageDesktopUrl, imageMobileUrl, captionText, position, id]
+  );
+  return true;
+}
+
+export async function deleteCarouselSlide(id) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const initialLength = store.carouselSlides.length;
+    store.carouselSlides = store.carouselSlides.filter((item) => Number(item.id) !== Number(id));
+    return store.carouselSlides.length !== initialLength;
+  }
+
+  await query("DELETE FROM carousel_slides WHERE id = $1", [id]);
+  return true;
+}
+
+// Agenda helpers
+export async function getAgendaEvents() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const sorted = sortByDateDesc(store.agendaEvents, (item) =>
+      item.fecha ? new Date(item.fecha).getTime() : null
+    );
+    return sorted.map((event) => ({
+      id: event.id,
+      titulo: event.titulo,
+      descripcion: event.descripcion,
+      fecha: event.fecha,
+      imageUrl: event.image_url,
+      tags: cloneTags(event.tags),
+    }));
+  }
+
+  const { rows } = await query(
+    `SELECT id, titulo, descripcion, fecha, image_url AS "imageUrl", tags
+     FROM agenda_events
+     ORDER BY fecha DESC NULLS LAST, id DESC`
+  );
+  return rows;
+}
+
+export async function createAgendaEvent({ titulo, descripcion, fecha, imageUrl, tags }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const id = allocateMemoryId("agendaEvents");
+    store.agendaEvents.push({
+      id,
+      titulo,
+      descripcion: descripcion || "",
+      fecha: fecha || null,
+      image_url: imageUrl || "",
+      tags: cloneTags(tags),
+    });
+    return { id };
+  }
+
+  const { rows } = await query(
+    `INSERT INTO agenda_events (titulo, descripcion, fecha, image_url, tags)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id`,
+    [titulo, descripcion || "", fecha || null, imageUrl || "", tags]
+  );
+  return rows[0];
+}
+
+export async function updateAgendaEvent(id, { titulo, descripcion, fecha, imageUrl, tags }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const event = store.agendaEvents.find((item) => Number(item.id) === Number(id));
+    if (!event) {
+      return false;
+    }
+    if (typeof titulo === "string") {
+      event.titulo = titulo;
+    }
+    if (typeof descripcion === "string") {
+      event.descripcion = descripcion;
+    }
+    if (typeof fecha !== "undefined") {
+      event.fecha = fecha || null;
+    }
+    if (typeof imageUrl === "string") {
+      event.image_url = imageUrl;
+    }
+    if (Array.isArray(tags)) {
+      event.tags = cloneTags(tags);
+    }
+    return true;
+  }
+
+  await query(
+    `UPDATE agenda_events
+     SET titulo = COALESCE($1, titulo),
+         descripcion = COALESCE($2, descripcion),
+         fecha = COALESCE($3, fecha),
+         image_url = COALESCE($4, image_url),
+         tags = COALESCE($5, tags)
+     WHERE id = $6`,
+    [titulo, descripcion, fecha, imageUrl, Array.isArray(tags) ? tags : null, id]
+  );
+  return true;
+}
+
+export async function deleteAgendaEvent(id) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const original = store.agendaEvents.length;
+    store.agendaEvents = store.agendaEvents.filter((item) => Number(item.id) !== Number(id));
+    return store.agendaEvents.length !== original;
+  }
+
+  await query("DELETE FROM agenda_events WHERE id = $1", [id]);
+  return true;
+}
+
+// Usina helpers
+export async function getUsinaPosts() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const posts = [...store.usinaPosts].sort((a, b) => Number(b.id) - Number(a.id));
+    return posts.map((post) => ({
+      id: post.id,
+      titulo: post.titulo,
+      texto: post.texto,
+      imageUrl: post.image_url,
+      tags: cloneTags(post.tags),
+    }));
+  }
+
+  const { rows } = await query(
+    `SELECT id, titulo, texto, image_url AS "imageUrl", tags
+     FROM usina_posts
+     ORDER BY id DESC`
+  );
+  return rows;
+}
+
+export async function createUsinaPost({ titulo, texto, imageUrl, tags }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const id = allocateMemoryId("usinaPosts");
+    store.usinaPosts.push({
+      id,
+      titulo,
+      texto: texto || "",
+      image_url: imageUrl || "",
+      tags: cloneTags(tags),
+    });
+    return { id };
+  }
+
+  const { rows } = await query(
+    `INSERT INTO usina_posts (titulo, texto, image_url, tags)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [titulo, texto || "", imageUrl || "", tags]
+  );
+  return rows[0];
+}
+
+export async function updateUsinaPost(id, { titulo, texto, imageUrl, tags }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const post = store.usinaPosts.find((item) => Number(item.id) === Number(id));
+    if (!post) {
+      return false;
+    }
+    if (typeof titulo === "string") {
+      post.titulo = titulo;
+    }
+    if (typeof texto === "string") {
+      post.texto = texto;
+    }
+    if (typeof imageUrl === "string") {
+      post.image_url = imageUrl;
+    }
+    if (Array.isArray(tags)) {
+      post.tags = cloneTags(tags);
+    }
+    return true;
+  }
+
+  await query(
+    `UPDATE usina_posts
+     SET titulo = COALESCE($1, titulo),
+         texto = COALESCE($2, texto),
+         image_url = COALESCE($3, image_url),
+         tags = COALESCE($4, tags)
+     WHERE id = $5`,
+    [titulo, texto, imageUrl, Array.isArray(tags) ? tags : null, id]
+  );
+  return true;
+}
+
+export async function deleteUsinaPost(id) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const original = store.usinaPosts.length;
+    store.usinaPosts = store.usinaPosts.filter((item) => Number(item.id) !== Number(id));
+    return store.usinaPosts.length !== original;
+  }
+
+  await query("DELETE FROM usina_posts WHERE id = $1", [id]);
+  return true;
+}
+
+// FAQ helpers
+export async function getFaqs() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const faqs = sortByPositionAndId(store.faqs);
+    return faqs.map((faq) => ({
+      id: faq.id,
+      question: faq.question,
+      answer: faq.answer,
+      position: faq.position,
+      tags: cloneTags(faq.tags),
+    }));
+  }
+
+  const { rows } = await query(
+    `SELECT id, question, answer, position, tags
+     FROM faqs
+     ORDER BY position ASC, id ASC`
+  );
+  return rows;
+}
+
+export async function getNextFaqPosition() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const max = store.faqs.reduce((acc, item) => {
+      const value = Number(item.position) || 0;
+      return value > acc ? value : acc;
+    }, 0);
+    return max + 1;
+  }
+
+  const { rows } = await query("SELECT COALESCE(MAX(position), 0) + 1 AS next FROM faqs");
+  return Number(rows[0]?.next || 1);
+}
+
+export async function createFaq({ question, answer, position, tags }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const id = allocateMemoryId("faqs");
+    const item = {
+      id,
+      question,
+      answer,
+      position,
+      tags: cloneTags(tags),
+    };
+    store.faqs.push(item);
+    return item;
+  }
+
+  const { rows } = await query(
+    `INSERT INTO faqs (question, answer, position, tags)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, question, answer, position, tags`,
+    [question, answer, position, tags]
+  );
+  return rows[0];
+}
+
+export async function updateFaq(id, { question, answer, position, tags }) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const faq = store.faqs.find((item) => Number(item.id) === Number(id));
+    if (!faq) {
+      return null;
+    }
+    if (typeof question === "string") {
+      faq.question = question;
+    }
+    if (typeof answer === "string") {
+      faq.answer = answer;
+    }
+    if (Number.isFinite(position)) {
+      faq.position = Number(position);
+    }
+    if (Array.isArray(tags)) {
+      faq.tags = cloneTags(tags);
+    }
+    return {
+      id: faq.id,
+      question: faq.question,
+      answer: faq.answer,
+      position: faq.position,
+      tags: cloneTags(faq.tags),
+    };
+  }
+
+  const setClauses = [];
+  const values = [];
+  if (typeof question !== "undefined") {
+    setClauses.push(`question = $${setClauses.length + 1}`);
+    values.push(question);
+  }
+  if (typeof answer !== "undefined") {
+    setClauses.push(`answer = $${setClauses.length + 1}`);
+    values.push(answer);
+  }
+  if (typeof position !== "undefined") {
+    setClauses.push(`position = $${setClauses.length + 1}`);
+    values.push(position);
+  }
+  if (typeof tags !== "undefined") {
+    setClauses.push(`tags = $${setClauses.length + 1}`);
+    values.push(tags);
+  }
+
+  if (!setClauses.length) {
+    return null;
+  }
+
+  values.push(id);
+
+  const { rows } = await query(
+    `UPDATE faqs
+       SET ${setClauses.join(", ")}
+     WHERE id = $${setClauses.length + 1}
+     RETURNING id, question, answer, position, tags`,
+    values
+  );
+
+  return rows[0] || null;
+}
+
+export async function deleteFaq(id) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const original = store.faqs.length;
+    store.faqs = store.faqs.filter((item) => Number(item.id) !== Number(id));
+    return store.faqs.length !== original;
+  }
+
+  const { rowCount } = await query(`DELETE FROM faqs WHERE id = $1`, [id]);
+  return Boolean(rowCount);
+}
+
+// Site texts
+export async function getSiteTexts() {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const texts = [...store.siteTexts].sort((a, b) => a.slug.localeCompare(b.slug));
+    return texts.map((item) => ({
+      id: item.id,
+      slug: item.slug,
+      titulo: item.titulo,
+      contenido: item.contenido,
+    }));
+  }
+
+  const { rows } = await query(
+    `SELECT id, slug, titulo, contenido
+     FROM site_texts
+     ORDER BY slug ASC`
+  );
+  return rows;
+}
+
+export async function getSiteTextBySlug(slug) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const item = store.siteTexts.find((entry) => entry.slug === slug);
+    return item
+      ? { id: item.id, slug: item.slug, titulo: item.titulo, contenido: item.contenido }
+      : null;
+  }
+
+  const { rows } = await query(
+    `SELECT id, slug, titulo, contenido FROM site_texts WHERE slug = $1 LIMIT 1`,
+    [slug]
+  );
+  return rows[0] || null;
+}
+
+export async function upsertSiteText(slug, titulo, contenido) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    let item = store.siteTexts.find((entry) => entry.slug === slug);
+    if (item) {
+      item.titulo = typeof titulo === "string" ? titulo : item.titulo;
+      item.contenido = typeof contenido === "string" ? contenido : item.contenido;
+    } else {
+      item = {
+        id: allocateMemoryId("siteTexts"),
+        slug,
+        titulo: titulo || "",
+        contenido: contenido || "",
+      };
+      store.siteTexts.push(item);
+    }
+    return item;
+  }
+
+  const { rowCount } = await query(
+    `UPDATE site_texts SET titulo = COALESCE($1, titulo), contenido = COALESCE($2, contenido) WHERE slug = $3`,
+    [titulo, contenido, slug]
+  );
+
+  if (!rowCount) {
+    await query(`INSERT INTO site_texts (slug, titulo, contenido) VALUES ($1, $2, $3)`, [slug, titulo || "", contenido || ""]);
+  }
+
+  return getSiteTextBySlug(slug);
+}
+
+// Site sections
+export async function getSiteSection(section) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    return store.siteSections.get(section) || null;
+  }
+
+  const { rows } = await query(`SELECT data FROM site_sections WHERE section = $1 LIMIT 1`, [section]);
+  return rows[0]?.data || null;
+}
+
+export async function upsertSiteSection(section, data) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    store.siteSections.set(section, data);
+    return data;
+  }
+
+  await query(
+    `INSERT INTO site_sections (section, data) VALUES ($1, $2)
+     ON CONFLICT (section) DO UPDATE SET data = EXCLUDED.data`,
+    [section, data]
+  );
+  return getSiteSection(section);
+}
+
+// Auth helpers
+export async function findUserByEmail(email) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    return store.users.find((user) => user.email === email) || null;
+  }
+
+  const { rows } = await query("SELECT * FROM users WHERE email = $1 LIMIT 1", [email]);
+  return rows[0] || null;
+}
+
+export async function findUserById(id) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const user = store.users.find((entry) => Number(entry.id) === Number(id));
+    if (!user) {
+      return null;
+    }
+    return { id: user.id, email: user.email, role: user.role };
+  }
+
+  const { rows } = await query("SELECT id, email, role FROM users WHERE id = $1", [id]);
+  return rows[0] || null;
+}
+
+export async function createLoginCode(userId, code, expiresAt) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    store.loginCodes.push({
+      id: allocateMemoryId("loginCodes"),
+      user_id: userId,
+      code,
+      expires_at: expiresAt instanceof Date ? expiresAt.toISOString() : new Date(expiresAt).toISOString(),
+    });
+    return;
+  }
+
+  await query(`INSERT INTO login_codes (user_id, code, expires_at) VALUES ($1, $2, $3)`, [userId, code, expiresAt]);
+}
+
+export async function findRecentLoginCodes(userId, limit = 5) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    const codes = store.loginCodes
+      .filter((entry) => Number(entry.user_id) === Number(userId))
+      .sort((a, b) => new Date(b.expires_at).getTime() - new Date(a.expires_at).getTime())
+      .slice(0, limit);
+    return codes;
+  }
+
+  const { rows } = await query(
+    `SELECT * FROM login_codes WHERE user_id = $1 ORDER BY expires_at DESC LIMIT $2`,
+    [userId, limit]
+  );
+  return rows;
+}
+
+export async function deleteLoginCodesByUser(userId) {
+  if (isUsingInMemoryDatabase()) {
+    const store = getMemoryStore();
+    store.loginCodes = store.loginCodes.filter((entry) => Number(entry.user_id) !== Number(userId));
+    return;
+  }
+
+  await query(`DELETE FROM login_codes WHERE user_id = $1`, [userId]);
+}


### PR DESCRIPTION
## Summary
- add default admin credentials and dynamic configuration warnings for development
- implement an in-memory data store with automatic seeding when PostgreSQL is unavailable
- refactor backend routes to use a shared data service that works with both the real database and the fallback store

## Testing
- node backend/src/server.js

------
https://chatgpt.com/codex/tasks/task_e_68ebd03c169c8331a4cfe436127309c4