### PR TITLE
Rediseñar las tarjetas del carrusel de agenda

### DIFF
--- a/src/app/components/Agenda.jsx
+++ b/src/app/components/Agenda.jsx
@@ -293,28 +293,6 @@ export default function Agenda() {
                       style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : undefined}
                     >
                       <div className={styles.cardHeroOverlay} />
-                      <div className={styles.cardHeroContent}>
-                        <div className={styles.heroDate}>
-                          <span className={styles.heroDay}>{dateParts.day || "--"}</span>
-                          <span className={styles.heroMonth}>{dateParts.month || ""}</span>
-                        </div>
-
-                        <h3 className={styles.heroTitle}>{event.titulo || "Evento sin titulo"}</h3>
-                        {humanDate ? <p className={styles.heroSchedule}>{humanDate}</p> : null}
-
-                        {(event.tags || []).length ? (
-                          <div className={styles.heroTags}>
-                            {(event.tags || []).map((tag, index) => (
-                              <span
-                                key={`${event.id}-tag-${index}`}
-                                className={`${styles.heroTag} ${styles[`heroTagVariant${(index % 5) + 1}`]}`}
-                              >
-                                {tag}
-                              </span>
-                            ))}
-                          </div>
-                        ) : null}
-                      </div>
                     </div>
 
                     <div className={styles.cardFooter}>
@@ -330,6 +308,18 @@ export default function Agenda() {
                         ) : (
                           <p className={styles.footerSummaryFallback}>Próximamente más información.</p>
                         )}
+                        {(event.tags || []).length ? (
+                          <div className={styles.footerTags}>
+                            {(event.tags || []).map((tag, index) => (
+                              <span
+                                key={`${event.id}-tag-${index}`}
+                                className={`${styles.footerTag} ${styles[`footerTagVariant${(index % 5) + 1}`]}`}
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
                       </div>
                     </div>
                   </article>

--- a/src/app/components/Agenda.jsx
+++ b/src/app/components/Agenda.jsx
@@ -288,11 +288,19 @@ export default function Agenda() {
 
                 return (
                   <article key={event.id} className={styles.card}>
-                    <div
-                      className={`${styles.cardHero} ${imageUrl ? "" : styles.cardHeroFallback}`.trim()}
-                      style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : undefined}
-                    >
-                      <div className={styles.cardHeroOverlay} />
+                    <div className={styles.cardHero}>
+                      {imageUrl ? (
+                        <img
+                          className={styles.cardImage}
+                          src={imageUrl}
+                          alt={event.titulo || "Imagen del evento"}
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className={styles.cardHeroFallback} aria-hidden="true">
+                          <span>Sin imagen</span>
+                        </div>
+                      )}
                     </div>
 
                     <div className={styles.cardFooter}>
@@ -309,12 +317,9 @@ export default function Agenda() {
                           <p className={styles.footerSummaryFallback}>Próximamente más información.</p>
                         )}
                         {(event.tags || []).length ? (
-                          <div className={styles.footerTags}>
+                          <div className={styles.tagList}>
                             {(event.tags || []).map((tag, index) => (
-                              <span
-                                key={`${event.id}-tag-${index}`}
-                                className={`${styles.footerTag} ${styles[`footerTagVariant${(index % 5) + 1}`]}`}
-                              >
+                              <span key={`${event.id}-tag-${index}`} className={styles.tag}>
                                 {tag}
                               </span>
                             ))}

--- a/src/app/components/Agenda.jsx
+++ b/src/app/components/Agenda.jsx
@@ -284,35 +284,53 @@ export default function Agenda() {
                 const summary = plainDescription
                   ? `${plainDescription.charAt(0).toUpperCase()}${plainDescription.slice(1)}`
                   : "";
+                const imageUrl = event.imageUrl ? asset(event.imageUrl) : "";
 
                 return (
                   <article key={event.id} className={styles.card}>
-                    {event.imageUrl ? (
-                      <img className={styles.cardImage} src={asset(event.imageUrl)} alt={event.titulo} />
-                    ) : (
-                      <div className={styles.cardPlaceholder} aria-hidden="true">
-                        <span>Sin imagen</span>
-                      </div>
-                    )}
-
-                    <div className={styles.cardBody}>
-                      <div className={styles.cardHeader}>
-                        <div className={styles.dateBadge}>
-                          <span className={styles.dateMonth}>{dateParts.month}</span>
-                          <span className={styles.dateDay}>{dateParts.day}</span>
+                    <div
+                      className={`${styles.cardHero} ${imageUrl ? "" : styles.cardHeroFallback}`.trim()}
+                      style={imageUrl ? { backgroundImage: `url(${imageUrl})` } : undefined}
+                    >
+                      <div className={styles.cardHeroOverlay} />
+                      <div className={styles.cardHeroContent}>
+                        <div className={styles.heroDate}>
+                          <span className={styles.heroDay}>{dateParts.day || "--"}</span>
+                          <span className={styles.heroMonth}>{dateParts.month || ""}</span>
                         </div>
-                        <div className={styles.tagList}>
-                          {(event.tags || []).map((tag, index) => (
-                            <span key={`${event.id}-tag-${index}`} className={styles.tag}>
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
+
+                        <h3 className={styles.heroTitle}>{event.titulo || "Evento sin titulo"}</h3>
+                        {humanDate ? <p className={styles.heroSchedule}>{humanDate}</p> : null}
+
+                        {(event.tags || []).length ? (
+                          <div className={styles.heroTags}>
+                            {(event.tags || []).map((tag, index) => (
+                              <span
+                                key={`${event.id}-tag-${index}`}
+                                className={`${styles.heroTag} ${styles[`heroTagVariant${(index % 5) + 1}`]}`}
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className={styles.cardFooter}>
+                      <div className={styles.footerDate}>
+                        <span className={styles.footerMonth}>{dateParts.month || ""}</span>
+                        <span className={styles.footerDay}>{dateParts.day || "--"}</span>
                       </div>
 
-                      <h3 className={styles.cardTitle}>{event.titulo || "Evento sin titulo"}</h3>
-                      {humanDate ? <p className={styles.cardDate}>{humanDate}</p> : null}
-                      {summary ? <p className={styles.cardSummary}>{summary}</p> : null}
+                      <div className={styles.footerInfo}>
+                        {humanDate ? <span className={styles.footerSchedule}>{humanDate}</span> : null}
+                        {summary ? (
+                          <p className={styles.footerSummary}>{summary}</p>
+                        ) : (
+                          <p className={styles.footerSummaryFallback}>Próximamente más información.</p>
+                        )}
+                      </div>
                     </div>
                   </article>
                 );

--- a/src/app/components/Agenda.jsx
+++ b/src/app/components/Agenda.jsx
@@ -16,6 +16,20 @@ const asset = (path) => {
   return `${base}${path}`;
 };
 
+const ArrowIcon = ({ direction = "right" }) => (
+  <svg
+    className={`${styles.navIcon} ${direction === "left" ? styles.navIconLeft : ""}`}
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      d="M8.47 4.47a.75.75 0 0 1 1.06 0l7 7a.75.75 0 0 1 0 1.06l-7 7a.75.75 0 1 1-1.06-1.06L14.94 12 8.47 5.53a.75.75 0 0 1 0-1.06Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 const formatDateParts = (value) => {
   if (!value) return { month: "", day: "" };
   const date = new Date(value);
@@ -196,7 +210,6 @@ export default function Agenda() {
     return items;
   }, [carouselEvents, currentIndex, effectiveColumns, canNavigate, total]);
 
-  const arrowIcon = asset("/malharrooficial/images/Icon_Agenda_Actualizado.svg");
   const trackStyle = { "--agenda-columns": `${Math.max(1, effectiveColumns)}` };
   const isExternalCta = /^https?:/i.test(ctaUrl || "");
 
@@ -262,7 +275,7 @@ export default function Agenda() {
                 onClick={handlePrev}
                 aria-label="Evento anterior"
               >
-                {arrowIcon ? <img src={arrowIcon} alt="Anterior" className={`${styles.navIcon} ${styles.navIconLeft}`} /> : <span>{"<"}</span>}
+                <ArrowIcon direction="left" />
               </button>
               <button
                 type="button"
@@ -270,7 +283,7 @@ export default function Agenda() {
                 onClick={handleNext}
                 aria-label="Evento siguiente"
               >
-                {arrowIcon ? <img src={arrowIcon} alt="Siguiente" className={styles.navIcon} /> : <span>{">"}</span>}
+                <ArrowIcon direction="right" />
               </button>
             </>
           ) : null}

--- a/src/app/components/AgendaHome.module.css
+++ b/src/app/components/AgendaHome.module.css
@@ -56,9 +56,9 @@
 }
 
 .card {
-  border-radius: 22px;
+  border-radius: 28px;
   overflow: hidden;
-  background: #f4155b;
+  background: #ffffff;
   color: #1c1630;
   display: flex;
   flex-direction: column;
@@ -66,102 +66,174 @@
   box-shadow: 0 24px 52px rgba(0, 0, 0, 0.28);
 }
 
-.cardImage {
+.cardHero {
+  position: relative;
+  min-height: 280px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.cardHeroFallback {
+  background-image: linear-gradient(135deg, #ff2d6d, #ff66a1);
+}
+
+.cardHeroOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 14, 22, 0.1) 0%, rgba(15, 14, 22, 0.8) 100%);
+}
+
+.cardHeroContent {
+  position: relative;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.cardPlaceholder {
-  height: 220px;
-  background: linear-gradient(135deg, #f8f0ff, #e8ddff);
-  color: #ffffff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.cardBody {
-  padding: 1.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.15rem;
-  flex: 1;
-}
-
-.cardHeader {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
   gap: 1rem;
-  align-items: flex-start;
+  place-items: center;
+  text-align: center;
+  color: #ffffff;
 }
 
-.dateBadge {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-width: 100px;
-  padding: 0.55rem 0.9rem;
-  border-radius: 18px;
-  color: #fff;
+.heroDate {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(8px);
 }
 
-.dateMonth {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.dateDay {
-  font-size: 1.75rem;
+.heroDay {
+  font-size: clamp(2.25rem, 7vw, 3rem);
   font-weight: 700;
   line-height: 1;
 }
 
-.tagList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  justify-content: flex-end;
+.heroMonth {
+  font-size: clamp(1rem, 3vw, 1.2rem);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 600;
 }
 
-.tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  background: rgb(255, 255, 255);
-  color: #000000;
-  font-size: 0.75rem;
+.heroTitle {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-weight: 700;
+  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.heroSchedule {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
   font-weight: 600;
-  text-transform: uppercase;
+  text-transform: capitalize;
   letter-spacing: 0.05em;
 }
 
-.cardTitle {
-  margin: 0;
-  font-size: 1.35rem;
+.heroTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: center;
+}
+
+.heroTag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
   font-weight: 700;
-  color: #ffffff;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(255, 255, 255, 0.85);
+  color: #1c1630;
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.18);
 }
 
-.cardDate {
-  margin: 0;
+.heroTagVariant1 {
+  background: rgba(66, 219, 182, 0.95);
+  color: #013529;
+}
+
+.heroTagVariant2 {
+  background: rgba(255, 233, 122, 0.95);
+  color: #4c3200;
+}
+
+.heroTagVariant3 {
+  background: rgba(114, 193, 255, 0.95);
+  color: #04254d;
+}
+
+.heroTagVariant4 {
+  background: rgba(255, 190, 210, 0.95);
+  color: #51132a;
+}
+
+.heroTagVariant5 {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1c1630;
+}
+
+.cardFooter {
+  background: linear-gradient(135deg, #142042, #202b5f);
+  color: #ffffff;
+  padding: clamp(1.4rem, 3vw, 1.75rem) clamp(1.4rem, 4vw, 2.25rem);
+  display: flex;
+  gap: clamp(1.1rem, 3vw, 1.8rem);
+  align-items: center;
+}
+
+.footerDate {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 72px;
+}
+
+.footerMonth {
   font-size: 0.95rem;
-  font-weight: 600;
-  color: #ffffff;
-  text-transform: capitalize;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
-.cardSummary {
+.footerDay {
+  font-size: clamp(2rem, 6vw, 2.6rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.footerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.footerSchedule {
+  font-size: 0.85rem;
+  text-transform: capitalize;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.footerSummary,
+.footerSummaryFallback {
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.6;
-  color: #ffffff;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.footerSummaryFallback {
+  font-style: italic;
 }
 
 .emptyState {
@@ -241,7 +313,7 @@
 
 @media (max-width: 1023px) {
   .cardsTrack {
-    grid-template-columnds: minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .navButtonLeft {
@@ -268,13 +340,27 @@
     margin: 0 auto;
   }
 
-  .cardBody {
-    padding: 1.5rem;
+  .cardHero {
+    min-height: 240px;
   }
 
-  .cardImage,
-  .cardPlaceholder {
-    height: 100%;
+  .cardHeroContent {
+    padding: 1.75rem 1.5rem 2.1rem;
+  }
+
+  .cardFooter {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .footerDate {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .footerDay {
+    font-size: 2.2rem;
   }
 
   .navButton {

--- a/src/app/components/AgendaHome.module.css
+++ b/src/app/components/AgendaHome.module.css
@@ -85,7 +85,7 @@
 
 .cardImage {
   object-fit: cover;
-  display: block;
+  
 }
 
 .cardHeroFallback {
@@ -208,6 +208,7 @@
 }
 
 .navButton {
+  z-index: 100;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);

--- a/src/app/components/AgendaHome.module.css
+++ b/src/app/components/AgendaHome.module.css
@@ -70,21 +70,29 @@
   position: relative;
   min-height: 280px;
   display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  background: #f2f2f2;
+  overflow: hidden;
+}
+
+.cardImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  flex: 1;
 }
 
 .cardHeroFallback {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background-image: linear-gradient(135deg, #ff2d6d, #ff66a1);
-}
-
-.cardHeroOverlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(15, 14, 22, 0.1) 0%, rgba(15, 14, 22, 0.8) 100%);
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .cardFooter {
@@ -140,51 +148,24 @@
   font-style: italic;
 }
 
-.footerTags {
+.tagList {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 0.4rem;
   margin-top: 0.5rem;
 }
 
-.footerTag {
+.tag {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.3rem 0.75rem;
+  padding: 0.25rem 0.6rem;
   border-radius: 999px;
+  background: #ffffff;
+  color: #000000;
   font-size: 0.75rem;
-  font-weight: 700;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  background: rgba(255, 255, 255, 0.85);
-  color: #1c1630;
-  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.18);
-}
-
-.footerTagVariant1 {
-  background: rgba(66, 219, 182, 0.95);
-  color: #013529;
-}
-
-.footerTagVariant2 {
-  background: rgba(255, 233, 122, 0.95);
-  color: #4c3200;
-}
-
-.footerTagVariant3 {
-  background: rgba(114, 193, 255, 0.95);
-  color: #04254d;
-}
-
-.footerTagVariant4 {
-  background: rgba(255, 190, 210, 0.95);
-  color: #51132a;
-}
-
-.footerTagVariant5 {
-  background: rgba(255, 255, 255, 0.9);
-  color: #1c1630;
+  letter-spacing: 0.05em;
 }
 
 .emptyState {

--- a/src/app/components/AgendaHome.module.css
+++ b/src/app/components/AgendaHome.module.css
@@ -68,23 +68,27 @@
 
 .cardHero {
   position: relative;
-  min-height: 280px;
-  display: flex;
-  background: #f2f2f2;
   overflow: hidden;
+  background: #0f0f16;
+  border-bottom: 1px solid rgba(15, 15, 22, 0.18);
+  aspect-ratio: 16 / 9;
+  min-height: clamp(220px, 32vw, 280px);
+}
+
+.cardImage,
+.cardHeroFallback {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .cardImage {
-  width: 100%;
-  height: 100%;
   object-fit: cover;
   display: block;
-  flex: 1;
 }
 
 .cardHeroFallback {
-  height: 100%;
-  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -236,7 +240,8 @@
 .navIcon {
   width: 20px;
   height: 20px;
-  filter: invert(1);
+  color: #ffffff;
+  transition: transform 0.2s ease;
 }
 
 .navIconLeft {
@@ -273,7 +278,8 @@
   }
 
   .cardHero {
-    min-height: 240px;
+    aspect-ratio: 4 / 3;
+    min-height: clamp(200px, 58vw, 240px);
   }
 
   .cardHeroContent {

--- a/src/app/components/AgendaHome.module.css
+++ b/src/app/components/AgendaHome.module.css
@@ -87,104 +87,8 @@
   background: linear-gradient(180deg, rgba(15, 14, 22, 0.1) 0%, rgba(15, 14, 22, 0.8) 100%);
 }
 
-.cardHeroContent {
-  position: relative;
-  padding: clamp(1.75rem, 4vw, 2.75rem);
-  width: 100%;
-  display: grid;
-  gap: 1rem;
-  place-items: center;
-  text-align: center;
-  color: #ffffff;
-}
-
-.heroDate {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.35rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  backdrop-filter: blur(8px);
-}
-
-.heroDay {
-  font-size: clamp(2.25rem, 7vw, 3rem);
-  font-weight: 700;
-  line-height: 1;
-}
-
-.heroMonth {
-  font-size: clamp(1rem, 3vw, 1.2rem);
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-weight: 600;
-}
-
-.heroTitle {
-  margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.4rem);
-  font-weight: 700;
-  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
-}
-
-.heroSchedule {
-  margin: 0;
-  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
-  font-weight: 600;
-  text-transform: capitalize;
-  letter-spacing: 0.05em;
-}
-
-.heroTags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  justify-content: center;
-}
-
-.heroTag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  background: rgba(255, 255, 255, 0.85);
-  color: #1c1630;
-  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.18);
-}
-
-.heroTagVariant1 {
-  background: rgba(66, 219, 182, 0.95);
-  color: #013529;
-}
-
-.heroTagVariant2 {
-  background: rgba(255, 233, 122, 0.95);
-  color: #4c3200;
-}
-
-.heroTagVariant3 {
-  background: rgba(114, 193, 255, 0.95);
-  color: #04254d;
-}
-
-.heroTagVariant4 {
-  background: rgba(255, 190, 210, 0.95);
-  color: #51132a;
-}
-
-.heroTagVariant5 {
-  background: rgba(255, 255, 255, 0.9);
-  color: #1c1630;
-}
-
 .cardFooter {
-  background: linear-gradient(135deg, #142042, #202b5f);
+  background: #ff155b;
   color: #ffffff;
   padding: clamp(1.4rem, 3vw, 1.75rem) clamp(1.4rem, 4vw, 2.25rem);
   display: flex;
@@ -234,6 +138,53 @@
 
 .footerSummaryFallback {
   font-style: italic;
+}
+
+.footerTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.5rem;
+}
+
+.footerTag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(255, 255, 255, 0.85);
+  color: #1c1630;
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.18);
+}
+
+.footerTagVariant1 {
+  background: rgba(66, 219, 182, 0.95);
+  color: #013529;
+}
+
+.footerTagVariant2 {
+  background: rgba(255, 233, 122, 0.95);
+  color: #4c3200;
+}
+
+.footerTagVariant3 {
+  background: rgba(114, 193, 255, 0.95);
+  color: #04254d;
+}
+
+.footerTagVariant4 {
+  background: rgba(255, 190, 210, 0.95);
+  color: #51132a;
+}
+
+.footerTagVariant5 {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1c1630;
 }
 
 .emptyState {


### PR DESCRIPTION
## Summary
- rediseñar la tarjeta del carrusel de agenda para replicar la disposición de la maqueta, con imagen de fondo, fecha destacada y etiquetas de colores
- actualizar los estilos del componente para mostrar un pie azul con fecha, descripción resumida y formato responsive

## Testing
- npm run lint *(falla: solicita configuración interactiva de ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68fa2e935c548331b343cc5435ce6a55